### PR TITLE
docs: add how to run e2e tests

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -1,0 +1,136 @@
+name: Build & run E2E tests
+
+on:
+  # make the workflow reusable
+  workflow_call:
+  # configure on push events
+  push:
+    paths:
+      - "e2e/**"
+      - "!e2e/**.md"
+    branches: [main]
+  # configure on pull request events
+  pull_request:
+    paths:
+      - "e2e/**"
+      - "!e2e/**.md"
+    branches: [main]
+
+jobs:
+  run-e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone E2E tests repo
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        with:
+          repository: USSF-ORBIT/ussf-portal
+          path: ./e2e-tests
+          fetch-depth: 0 # fetch all branch information, needed to checkout the branch if present later
+          ref: main      # checkout main by default
+
+      - name: Checkout E2E ${{github.head_ref}} or main
+        working-directory: ./e2e-tests
+        run: |
+          # checkout the branch that started this pull request or stay on main if no such branch
+          /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
+
+      - name: Clone portal client
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        with:
+          repository: USSF-ORBIT/ussf-portal-client
+          path: ./ussf-portal-client
+          fetch-depth: 0 # fetch all branch information, needed to checkout the branch if present later
+          ref: main      # checkout main by default
+
+      - name: Checkout portal client ${{github.head_ref}} or main
+        working-directory: ./ussf-portal-client
+        run: |
+          # checkout the branch that started this pull request or stay on main if no such branch
+          /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
+
+      - name: Clone cms
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        with:
+          repository: USSF-ORBIT/ussf-portal-cms
+          path: ./ussf-portal-cms
+          fetch-depth: 0 # fetch all branch information, needed to checkout the branch if present later
+          ref: main      # checkout main by default
+
+      - name: Checkout cms ${{github.head_ref}} or main
+        working-directory: ./ussf-portal-cms
+        run: |
+          # checkout the branch that started this pull request or stay on main if no such branch
+          /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
+
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./e2e-tests/e2e/package.json').engines.node")
+        id: engines
+
+      - name: Set up node
+        uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # tag=v3
+        with:
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
+
+      - name: Docker compose
+        run: docker-compose up -d
+        working-directory: ./e2e-tests/e2e
+
+      - name: Docker logs
+        uses: jwalton/gh-docker-logs@v2.2.0
+        with:
+          dest: "./docker-logs"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: ./e2e-tests/e2e
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+        working-directory: ./e2e-tests/e2e
+
+      - name: Run Playwright tests
+        run: yarn playwright test
+        working-directory: ./e2e-tests/e2e
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3
+        with:
+          name: playwright-results
+          path: ./e2e-tests/e2e/test-results
+
+      - name: Cypress run
+        uses: cypress-io/github-action@31b3f686c1ee05fb7390cc106d1f09eb83919a3c # tag=v3.2.0
+        env:
+          CYPRESS_BASE_URL: http://localhost:3000
+        with:
+          install-command: yarn install --frozen-lockfile
+          working-directory: ./e2e-tests/e2e
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: ./e2e-tests/e2e/cypress/screenshots
+
+      - name: Upload videos
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3
+        if: always()
+        with:
+          name: cypress-videos
+          path: ./e2e-tests/e2e/cypress/videos
+
+      - name: Upload reports
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3
+        if: always()
+        with:
+          name: cypress-reports
+          path: ./e2e-tests/e2e/cypress/reports
+
+      - name: Upload logs
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3
+        if: always()
+        with:
+          name: container-logs
+          path: ./docker-logs

--- a/.github/workflows/skip-e2e-tests.yml
+++ b/.github/workflows/skip-e2e-tests.yml
@@ -1,19 +1,21 @@
-name: Run E2E tests when changed
+name: Skip E2E tests when only docs changed
 
 on:
   # configure on push events
   push:
     paths:
-      - "e2e/**"
+      - "**.md"
+      - "!e2e/**"
     branches: [main]
   # configure on pull request events
   pull_request:
     paths:
-      - "e2e/**"
+      - "**.md"
+      - "!e2e/**"
     branches: [main]
 
 jobs:
   run-e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/workflows/reusable-run-e2e-tests
+      - run: echo "skip e2e tests for doc only changes"

--- a/docs/how-to/run-or-update-e2e-tests.md
+++ b/docs/how-to/run-or-update-e2e-tests.md
@@ -1,0 +1,59 @@
+# How To Run and/or Update the End-to-End (E2E) tests
+
+## Run E2E tests locally
+
+### 0. Pre-requisites
+
+The e2e tests rely on the client and cms repos being present. It is assumed that they are checked out at the same level as this `ussf-portal` repo and have the default names `ussf-portal-client` and `ussf-portal-cms`.
+
+### Change directory
+
+You will need to be in the `e2e` directory
+
+`cd e2e`
+
+### Install cypress & playwright
+
+You will need the dependencies installed so run the following.
+
+```sh
+yarn
+yarn cypress:install
+yarn e2e:install
+```
+
+### Shutdown any other docker containers
+
+Since the normal services can conflict with the current setup of e2e tests you probably want to shut everything else down. The following command will remove all containers.
+
+`yarn services:removeall`
+
+### Start the services
+
+You will need everything running before running any of the tests. This repo has a docker compose file that does just that. Since this command will build the client and cms docker images it can take a while.
+
+`yarn services:up`
+
+> NOTE: this will start everything in the forground which can be helpful for debugging, but you can run the following to start in the background if that's prefered.
+
+`yarn services:up -d`
+
+### Run E2E tests in github actions manually
+
+Once the services are up, may take a while sometimes keystone database takes a bit to start up. 
+
+Now you can run the playwright based tests
+
+`yarn e2e:test`
+
+And/Or the cypress based tests
+
+`yarn cypress:dev`
+
+## Standard workflow
+
+The e2e tests for the portal client and cms live in this repository now. During the pull request stage for the workflows to pass in this repository or the others you will need to use the **same _branch name_** in all 3 repos.
+
+Update the code as usual in client or cms repos. Then update or write the e2e tests once the PRs are in the review stage.
+
+> NOTE the workflow for running the e2e tests is run during the cms and client repos, but at this time is not required to avoid having the flakey tests hold up every PR. It will be the responsibility of the PR author and reviewers to ensure that PRs are not breaking the e2e tests in an unexpected way. The expectation is that we will require this to pass again once the job is shorter and much less flakey.


### PR DESCRIPTION
# [Epic SC-720](https://app.shortcut.com/orbit-truss/epic/720/separate-e2e-tests-from-client-and-cms-repos)

## Proposed changes

Add documentation on how to run and update the E2E tests now that they have moved to their own repostiroy.

## Reviewer notes

Read and try `docs/how-to/run-or-update-e2e-tests.md`

## Setup

See `docs/how-to/run-or-update-e2e-tests.md`
