### PR TITLE
ci: improve docker build times using ecr cache

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -59,10 +59,27 @@ jobs:
         with:
           node-version: ${{ steps.engines.outputs.nodeVersion }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1
+        with:
+          aws-access-key-id: ${{ secrets.GHA_ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GHA_ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.GHA_ECR_ROLE_ASSUMPTION }}
+          role-skip-session-tagging: true
+          role-duration-seconds: '3600'
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f # tag=v1
+
       - name: Docker compose
         run: docker-compose up -d
         working-directory: ./e2e-tests/e2e
-
+        env:
+          CMS_REPO: ${{ steps.login-ecr.outputs.registry }}/keystone
+          PORTAL_REPO: ${{ steps.login-ecr.outputs.registry }}/portal-client
+          
       - name: Docker logs
         uses: jwalton/gh-docker-logs@v2.2.0
         with:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   run-e2e-tests:
     uses: ./.github/workflows/reusable-run-e2e-tests.yml
+    secrets: inherit
 
   lint-e2e-tests:
     runs-on: ubuntu-latest

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       context: ../../ussf-portal-client/
       dockerfile: Dockerfile
       target: e2e
+      cache_from:
+        - "${PORTAL_REPO}:builder"
+        - "${PORTAL_REPO}:e2e"
     restart: always
     ports:
       - '3000:3000'
@@ -35,6 +38,9 @@ services:
       context: ../../ussf-portal-cms/
       dockerfile: Dockerfile
       target: e2e
+      cache_from:
+        - "${CMS_REPO}:builder"
+        - "${CMS_REPO}:e2e"
     restart: always
     ports:
       - '3001:3001'


### PR DESCRIPTION
# SC-916

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

- login to ECR and pass CMS and Portal Client repository IDs to docker-compose.yml
- docker-compose.yml will use the cache when available, otherwise will build without it

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

You can test that the docker-compose.yml file still works locally. I recommend cloning the [e2e repo](https://github.com/USSF-ORBIT/ussf-portal) and running `yarn services:up` from inside the /e2e folder. This will test the Dockerfile changes with `docker compose`.

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [ ] Checked that the E2E test build is not failing

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
