### PR TITLE
ci: update reusable-run-e2e-tests.yml

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f # tag=v1
 
       - name: Docker compose
-        run: docker-compose up -d
+        run: docker compose up -d
         working-directory: ./e2e-tests/e2e
         env:
           CMS_REPO: ${{ steps.login-ecr.outputs.registry }}/keystone


### PR DESCRIPTION
used docker-compose instead of docker compose

# SC-916

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

- change `docker-compose` cmd to `docker compose` to use docker v2

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
