### PR TITLE
ci: capture docker logs later

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -80,11 +80,6 @@ jobs:
           CMS_REPO: ${{ steps.login-ecr.outputs.registry }}/keystone
           PORTAL_REPO: ${{ steps.login-ecr.outputs.registry }}/portal-client
           
-      - name: Docker logs
-        uses: jwalton/gh-docker-logs@v2.2.0
-        with:
-          dest: "./docker-logs"
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         working-directory: ./e2e-tests/e2e
@@ -111,7 +106,12 @@ jobs:
         with:
           install-command: yarn install --frozen-lockfile
           working-directory: ./e2e-tests/e2e
-
+          
+      - name: Docker logs
+        uses: jwalton/gh-docker-logs@v2.2.0
+        with:
+          dest: "./docker-logs"
+          
       - name: Upload screenshots
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3
         if: failure()

--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f # tag=v1
 
       - name: Docker compose
-        run: docker compose up -d
+        run: docker compose up -d --no-TTY 
         working-directory: ./e2e-tests/e2e
         env:
           CMS_REPO: ${{ steps.login-ecr.outputs.registry }}/keystone

--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f # tag=v1
 
       - name: Docker compose
-        run: docker compose up -d --no-TTY 
+        run: docker compose up -d
         working-directory: ./e2e-tests/e2e
         env:
           CMS_REPO: ${{ steps.login-ecr.outputs.registry }}/keystone


### PR DESCRIPTION
move gh-docker-logs later in the e2e workflow