### PR TITLE
ci: always capture docker logs

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -109,6 +109,7 @@ jobs:
           
       - name: Docker logs
         uses: jwalton/gh-docker-logs@v2.2.0
+        if: ${{ always() }}
         with:
           dest: "./docker-logs"
           


### PR DESCRIPTION
- always capture docker logs in e2e workflow, even when playwright or cypress fail
