### PR TITLE
build: support local file to set launch darkly flags

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -85,11 +85,11 @@ jobs:
         working-directory: ./e2e-tests/e2e
 
       - name: Wait for CMS sysinfo to return 200
-        run: yarn wait-on --timeout 60000 http://localhost:3001
+        run: yarn wait-on --timeout 60000 http://localhost:3001/api/sysinfo
         working-directory: ./e2e-tests/e2e
 
       - name: Wait for Client sysinfo to return 200
-        run: yarn wait-on --timeout 60000 http://localhost:3000
+        run: yarn wait-on --timeout 60000 http://localhost:3000/api/sysinfo
         working-directory: ./e2e-tests/e2e
 
       - name: Install Playwright

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,8 +1,8 @@
 # Docker compose stack for E2E tests
 services:
   # Portal client
-  app:
-    container_name: app
+  client:
+    container_name: client
     build:
       context: ../../ussf-portal-client/
       dockerfile: Dockerfile
@@ -25,6 +25,7 @@ services:
       SESSION_SECRET: thisvaluecanbeanythingitisonlyforlocaldevelopment
       SESSION_DOMAIN: localhost
       KEYSTONE_URL: http://cms:3001
+      LAUNCHDARKLY_SDK_CLIENT_SIDE_ID: localfile
     stdin_open: true
     depends_on:
       - mongo
@@ -58,7 +59,7 @@ services:
       redis:
         condition: service_started
 
-  # Required by Portal app
+  # Required by Portal client
   mongo:
     container_name: mongo
     image: mongo:4.0.0
@@ -68,7 +69,7 @@ services:
     ports:
       - '27017:27017'
 
-  # Shared between CMS and Portal app
+  # Shared between CMS and Portal client
   redis:
     container_name: portal_redis
     image: redis:6.2

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,6 +10,7 @@
     "lint": "tsc --noEmit && eslint .",
     "services:removeall": "docker ps --quiet --all | xargs docker rm --force",
     "services:up": "docker compose up --build --force-recreate --remove-orphans",
+    "services:down": "docker compose down",
     "cypress:install": "yarn --cwd e2e/ install",
     "cypress:dev": "yarn --cwd e2e/ cypress open",
     "cypress:test": "yarn --cwd e2e/ cypress run",


### PR DESCRIPTION
# SC-1248

## Proposed changes

As part of adding ` LAUNCHDARKLY_SDK_CLIENT_SIDE_ID` to the checked vars the portal client doesn't start up. This PR adds a value for it so that the server will start up. It uses the recently added local configuration option defined in USSF-ORBIT/ussf-portal-client#839. 839 isn't required for this PR to pass the build, but that PR requires the changes in this PR.

## Reviewer notes

Make sure the build passes, try it locally if you want.