### PR TITLE
chore: make local e2e builds work on all platforms

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     build:
       context: ../../ussf-portal-cms/
       dockerfile: Dockerfile
-      target: e2e
+      target: "e2e${LOCAL_BUILD}"
       cache_from:
         - "${CMS_REPO}:builder"
         - "${CMS_REPO}:e2e"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "tsc --noEmit && eslint .",
     "services:removeall": "docker ps --quiet --all | xargs docker rm --force",
-    "services:up": "docker compose up --build --force-recreate --remove-orphans",
+    "services:up": "LOCAL_BUILD='-local' docker compose up --build --force-recreate --remove-orphans",
     "services:down": "docker compose down",
     "cypress:install": "yarn --cwd e2e/ install",
     "cypress:dev": "yarn --cwd e2e/ cypress open",


### PR DESCRIPTION
This update allows local e2e builds to work on all platforms, since distroless does not build on M1 Macbooks without requiring changes to the Dockerfile.

Test this out locally with `yarn services:up` and `yarn e2e:test` as you normally would do to run local e2e tests.