### PR TITLE
test: skip tests that are extra flakey but slated for playwright conversion

### DIFF
--- a/e2e/cypress/e2e/sites-and-applications.cy.js
+++ b/e2e/cypress/e2e/sites-and-applications.cy.js
@@ -151,7 +151,8 @@ describe('Sites and Applications', () => {
       })
   })
 
-  it('can add links to an existing collection from the Sites & Applications page', () => {
+  // TODO convert this test to playwright to see if it can be stablilzed
+  it.skip('can add links to an existing collection from the Sites & Applications page', () => {
     // Client-side navigate to the page
     cy.contains('All sites & applications').click()
 
@@ -187,7 +188,8 @@ describe('Sites and Applications', () => {
       })
   })
 
-  it('can hide links from an existing collection', () => {
+  // TODO convert this test to playwright to see if it can be stablilzed
+  it.skip('can hide links from an existing collection', () => {
     cy.contains('My Space')
 
     cy.contains('Example Collection')
@@ -274,7 +276,8 @@ describe('Sites and Applications', () => {
     cy.contains('My Custom Link')
   })
 
-  it('can edit custom links', () => {
+  // TODO convert this test to playwright to see if it can be stablilzed
+  it.skip('can edit custom links', () => {
     cy.contains('Example Collection')
       .parent()
       .parent()
@@ -357,7 +360,8 @@ describe('Sites and Applications', () => {
       })
   })
 
-  it('can remove multiple links at once from an existing collection', () => {
+  // TODO convert this test to playwright to see if it can be stablilzed
+  it.skip('can remove multiple links at once from an existing collection', () => {
     cy.contains('My Space')
 
     cy.contains('Updated Title')


### PR DESCRIPTION
# SC-1248

## Proposed changes

Disable some flakey tests 😞 

## Reviewer notes

Some of the tests in the `sites-and-applications.cy.js` are extra flakey. I spent time trying to diagnose it but have come to an impasse. So after discussing this internally we've decided to turn off these tests for now pending when we can convert them to playwright. Conversion to playwright is blocked by sc-1375.

## Setup

`yarn services:up`
`yarn cypress:test`