### PR TITLE
chore: changed run-e2e-tests job to check-e2e-tests

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -158,7 +158,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["run-e2e-tests", "lint-e2e-tests"]
+        contexts: ["check-e2e-tests", "lint-e2e-tests"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Commits pushed to matching branches must have verified signatures. Set to false to disable.

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -16,7 +16,7 @@ on:
     branches: [main]
 
 jobs:
-  run-e2e-tests:
+  check-e2e-tests:
     uses: ./.github/workflows/reusable-run-e2e-tests.yml
     secrets: inherit
 

--- a/.github/workflows/skip-e2e-tests.yml
+++ b/.github/workflows/skip-e2e-tests.yml
@@ -21,7 +21,7 @@ on:
     branches: [main]
 
 jobs:
-  run-e2e-tests:
+  check-e2e-tests:
     runs-on: ubuntu-latest
     steps:
       - run: echo "skip e2e tests for doc only changes"


### PR DESCRIPTION


<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- change the job title of `run-e2e-tests` in `.github/workflows/run-e2e-tests.yml` and `.github/workflows/skip-e2e-tests.yml` to `check-e2e-tests` to differentiate from the reusable job
- also makes it more clear that the job is a check for whether e2e tests will run, and that the e2e tests can be skipped in some runs

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
