### PR TITLE
test: add test for carousel showing hero image

### DIFF
--- a/e2e/playwright/feature/article-hero-carousel.spec.ts
+++ b/e2e/playwright/feature/article-hero-carousel.spec.ts
@@ -50,7 +50,7 @@ test('hero image is displayed by on internal news carousel', async ({
   /** Create a new article *****
 
     Category: InternalNews
-    Title: My Test Article
+    Title: <Generated using Faker>
     Hero Image: placeholder.png 
     ****************************/
 

--- a/e2e/playwright/feature/article-hero-carousel.spec.ts
+++ b/e2e/playwright/feature/article-hero-carousel.spec.ts
@@ -1,0 +1,143 @@
+import { test as base } from '@playwright/test'
+import path from 'path'
+import { faker } from '@faker-js/faker'
+import {
+  fixtures,
+  TestingLibraryFixtures,
+} from '@playwright-testing-library/test/fixture'
+import { authorUser, managerUser } from '../cms/database/users'
+import { LoginPage } from '../models/Login'
+
+type CustomFixtures = {
+  loginPage: LoginPage
+}
+
+const test = base.extend<TestingLibraryFixtures & CustomFixtures>({
+  ...fixtures,
+  loginPage: async ({ page, context }, use) => {
+    await use(new LoginPage(page, context))
+  },
+})
+
+const { expect } = test
+
+let title: string
+
+test.beforeAll(async () => {
+  title = faker.lorem.words()
+})
+
+test('hero image is displayed by on internal news carousel', async ({
+  page,
+  loginPage,
+}) => {
+  /* Log in as a CMS author */
+  await loginPage.login(authorUser.username, authorUser.password)
+
+  await expect(page.locator('text=WELCOME, ETHEL NEAL')).toBeVisible()
+
+  await page.goto('http://localhost:3001')
+  await expect(
+    page.locator('text=Signed in as ETHEL.NEAL.643097412@testusers.cce.af.mil')
+  ).toBeVisible()
+
+  /* Navigate to the Articles page */
+  await Promise.all([
+    page.waitForNavigation(),
+    page.locator('h3:has-text("Articles")').click(),
+  ])
+
+  /** Create a new article *****
+
+    Category: InternalNews
+    Title: My Test Article
+    Hero Image: placeholder.png 
+    ****************************/
+
+  await page.locator('text=Create Article').click()
+  await page.locator('label[for="category"]').click()
+  await page.keyboard.type('I')
+  await page.keyboard.press('Enter')
+  await page.locator('#title').fill(title)
+
+  /* Use fileChooser to upload a hero image */
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.locator('text=Upload').click(),
+  ])
+  await fileChooser.setFiles(path.resolve(__dirname, 'placeholder.png'))
+
+  /* Create article */
+  await Promise.all([
+    page.waitForNavigation(),
+    page.locator('form span:has-text("Create Article")').click(),
+  ])
+
+  /* Confirm image has successfully uploaded and saved */
+  await expect(
+    page.locator('img[alt="Image uploaded to hero field"]')
+  ).toBeVisible()
+
+  /* Navigate back to Articles page and confirm article was created as a draft */
+
+  await page.locator('[aria-label="Side Navigation"] >> text=Articles').click()
+  await expect(page).toHaveURL('http://localhost:3001/articles')
+
+  await expect(
+    page.locator(`tr:has-text("${title}") td:nth-child(3)`)
+  ).toHaveText('Draft')
+
+  /* Log out as CMS author */
+  await loginPage.logout()
+
+  /* Log in as a CMS manager */
+  await loginPage.login(managerUser.username, managerUser.password)
+  await expect(page.locator('text=WELCOME, CHRISTINA HAVEN')).toBeVisible()
+
+  await page.goto('http://localhost:3001')
+  await expect(
+    page.locator(
+      'text=Signed in as CHRISTINA.HAVEN.561698119@testusers.cce.af.mil'
+    )
+  ).toBeVisible()
+
+  /* Navigate to the Articles page */
+  await Promise.all([
+    page.waitForNavigation(),
+    page.locator('h3:has-text("Articles")').click(),
+  ])
+
+  /* Publish article */
+  await page.locator(`a:has-text("${title}")`).click()
+
+  await page.locator('label:has-text("Published")').check()
+
+  await page.locator('button:has-text("Save changes")').click()
+
+  /* View article on the portal and confirm hero is present */
+  await page.goto('http://localhost:3000/news-announcements')
+
+  const carouselCard = page.locator(`div:has-text("${title}") > .grid-row >> nth=0`)
+
+  await expect(carouselCard).toBeVisible()
+
+  /* Verify that the hero image is displayed on the carousel */
+  await expect(
+    carouselCard.locator('img[alt="article hero graphic"]')
+  ).toBeVisible()
+
+  // Start waiting for new page before clicking
+  const [article] = await Promise.all([
+    page.waitForEvent('popup'),
+    carouselCard.locator('text=View Article').click(),
+  ])
+
+  await expect(article.locator(`article >> h2:has-text("${title}")`)).toBeVisible()
+
+  /* Verify that the hero image is displayed when viewing the article */
+  await expect(article.locator('article >> img[alt="article hero graphic"]')).toBeVisible()
+
+  /* Return to CMS and log out */
+  await page.goto('http://localhost:3001')
+  await loginPage.logout()
+})


### PR DESCRIPTION
# SC-1394

## Proposed changes

Add new e2e test for showing the hero image in the carousel for Internal News articles

## Reviewer notes

This is largely copied from the article hero spec. It's in a separate file to facilitate parallel tests and also tests seeing a hero image for the Internal News articles, even though the underling code for it is shared with Orbit blog articles.

## Setup

Run the e2e tests if you like:
```sh
yarn services:up -d
yarn wait-on http://localhost:3000/api/sysinfo http://localhost:3001/api/sysinfo && yarn e2e:test
```