### PR TITLE
test: e2e improvements

### DIFF
--- a/e2e/playwright/cms/tests/tracking.spec.ts
+++ b/e2e/playwright/cms/tests/tracking.spec.ts
@@ -1,12 +1,19 @@
 import { test as base } from '@playwright/test'
+import { KeystoneListPage } from '../../models/KeystoneList'
 import { LoginPage } from '../../models/Login'
 import { adminUser, defaultUser } from '../database/users'
 
-const test = base.extend<{ loginPage: LoginPage }>({
-  loginPage: async ({ page, context }, use) => {
-    await use(new LoginPage(page, context))
-  },
-})
+const test = base
+  .extend<{ loginPage: LoginPage }>({
+    loginPage: async ({ page, context }, use) => {
+      await use(new LoginPage(page, context))
+    },
+  })
+  .extend<{ keystoneListPage: KeystoneListPage }>({
+    keystoneListPage: async ({ page, context }, use) => {
+      await use(new KeystoneListPage(page, context))
+    },
+  })
 
 const { describe, expect } = test
 
@@ -14,6 +21,7 @@ describe('Event logging', () => {
   test('making changes to the data automatically creates events', async ({
     page,
     loginPage,
+    keystoneListPage,
   }) => {
     await loginPage.login(defaultUser.username, defaultUser.password)
 
@@ -55,17 +63,7 @@ describe('Event logging', () => {
 
     // Sort events in descending order and choose the first
     // This will pull up the most recent event
-    await page.locator('button:has-text("No field")').click()
-
-    await page.locator('input[role="combobox"]').fill('updated')
-    await page.locator('input[role="combobox"]').press('Enter')
-    await expect(page).toHaveURL(
-      'http://localhost:3001/events?sortBy=updatedAt'
-    )
-    // Must re-click 'Updated At' dropdown option to get to descending order
-    await page.locator('button:has-text("Updated At ascending")').click()
-    await page.locator('input[role="combobox"]').fill('updated')
-    await page.locator('input[role="combobox"]').press('Enter')
+    await keystoneListPage.gotoAndSortBy('events')
 
     await Promise.all([
       page.waitForNavigation(),

--- a/e2e/playwright/feature/article-hero-carousel.spec.ts
+++ b/e2e/playwright/feature/article-hero-carousel.spec.ts
@@ -117,7 +117,9 @@ test('hero image is displayed by on internal news carousel', async ({
   /* View article on the portal and confirm hero is present */
   await page.goto('http://localhost:3000/news-announcements')
 
-  const carouselCard = page.locator(`div:has-text("${title}") > .grid-row >> nth=0`)
+  const carouselCard = page.locator(
+    `div:has-text("${title}") > .grid-row >> nth=0`
+  )
 
   await expect(carouselCard).toBeVisible()
 
@@ -132,10 +134,14 @@ test('hero image is displayed by on internal news carousel', async ({
     carouselCard.locator('text=View Article').click(),
   ])
 
-  await expect(article.locator(`article >> h2:has-text("${title}")`)).toBeVisible()
+  await expect(
+    article.locator(`article >> h2:has-text("${title}")`)
+  ).toBeVisible()
 
   /* Verify that the hero image is displayed when viewing the article */
-  await expect(article.locator('article >> img[alt="article hero graphic"]')).toBeVisible()
+  await expect(
+    article.locator('article >> img[alt="article hero graphic"]')
+  ).toBeVisible()
 
   /* Return to CMS and log out */
   await page.goto('http://localhost:3001')

--- a/e2e/playwright/feature/article-hero-carousel.spec.ts
+++ b/e2e/playwright/feature/article-hero-carousel.spec.ts
@@ -7,15 +7,20 @@ import {
 } from '@playwright-testing-library/test/fixture'
 import { authorUser, managerUser } from '../cms/database/users'
 import { LoginPage } from '../models/Login'
+import { KeystoneListPage } from '../models/KeystoneList'
 
 type CustomFixtures = {
   loginPage: LoginPage
+  keystoneListPage: KeystoneListPage
 }
 
 const test = base.extend<TestingLibraryFixtures & CustomFixtures>({
   ...fixtures,
   loginPage: async ({ page, context }, use) => {
     await use(new LoginPage(page, context))
+  },
+  keystoneListPage: async ({ page, context }, use) => {
+    await use(new KeystoneListPage(page, context))
   },
 })
 
@@ -30,7 +35,9 @@ test.beforeAll(async () => {
 test('hero image is displayed by on internal news carousel', async ({
   page,
   loginPage,
+  keystoneListPage,
 }) => {
+  test.slow()
   /* Log in as a CMS author */
   await loginPage.login(authorUser.username, authorUser.password)
 
@@ -79,10 +86,7 @@ test('hero image is displayed by on internal news carousel', async ({
   ).toBeVisible()
 
   /* Navigate back to Articles page and confirm article was created as a draft */
-
-  await page.locator('[aria-label="Side Navigation"] >> text=Articles').click()
-  await expect(page).toHaveURL('http://localhost:3001/articles')
-
+  await keystoneListPage.gotoAndSortBy('articles')
   await expect(
     page.locator(`tr:has-text("${title}") td:nth-child(3)`)
   ).toHaveText('Draft')

--- a/e2e/playwright/feature/article-hero.spec.ts
+++ b/e2e/playwright/feature/article-hero.spec.ts
@@ -7,15 +7,20 @@ import {
 } from '@playwright-testing-library/test/fixture'
 import { authorUser, managerUser } from '../cms/database/users'
 import { LoginPage } from '../models/Login'
+import { KeystoneListPage } from '../models/KeystoneList'
 
 type CustomFixtures = {
   loginPage: LoginPage
+  keystoneListPage: KeystoneListPage
 }
 
 const test = base.extend<TestingLibraryFixtures & CustomFixtures>({
   ...fixtures,
   loginPage: async ({ page, context }, use) => {
     await use(new LoginPage(page, context))
+  },
+  keystoneListPage: async ({ page, context }, use) => {
+    await use(new KeystoneListPage(page, context))
   },
 })
 
@@ -30,6 +35,7 @@ describe('Article Hero Image', () => {
   test('hero image can be uploaded and saved by an author', async ({
     page,
     loginPage,
+    keystoneListPage,
   }) => {
     test.slow()
 
@@ -84,10 +90,7 @@ describe('Article Hero Image', () => {
 
     /* Navigate back to Articles page and confirm article was created as a draft */
 
-    await page
-      .locator('[aria-label="Side Navigation"] >> text=Articles')
-      .click()
-    await expect(page).toHaveURL('http://localhost:3001/articles')
+    await keystoneListPage.gotoAndSortBy('articles')
 
     await expect(
       page.locator(`tr:has-text("${title}") td:nth-child(3)`)
@@ -99,6 +102,7 @@ describe('Article Hero Image', () => {
   test('hero image can be viewed on published article', async ({
     page,
     loginPage,
+    keystoneListPage,
   }) => {
     /* Log in as a CMS manager */
     await loginPage.login(managerUser.username, managerUser.password)
@@ -112,10 +116,7 @@ describe('Article Hero Image', () => {
     ).toBeVisible()
 
     /* Navigate to the Articles page */
-    await Promise.all([
-      page.waitForNavigation(),
-      page.locator('h3:has-text("Articles")').click(),
-    ])
+    await keystoneListPage.gotoAndSortBy('articles')
 
     /* Publish article */
     await page.locator(`a:has-text("${title}")`).click()

--- a/e2e/playwright/models/KeystoneList.ts
+++ b/e2e/playwright/models/KeystoneList.ts
@@ -1,14 +1,12 @@
-import { expect, Locator, BrowserContext, Page } from '@playwright/test'
+import { expect, BrowserContext, Page } from '@playwright/test'
 
 export class KeystoneListPage {
   readonly page: Page
   readonly context: BrowserContext
-  readonly filterButton: Locator
 
   constructor(page: Page, context: BrowserContext) {
     this.page = page
     this.context = context
-    this.filterButton = page.locator('text=Log In')
   }
 
   async gotoAndSortBy(

--- a/e2e/playwright/models/KeystoneList.ts
+++ b/e2e/playwright/models/KeystoneList.ts
@@ -1,0 +1,29 @@
+import { expect, Locator, BrowserContext, Page } from '@playwright/test'
+
+export class KeystoneListPage {
+  readonly page: Page
+  readonly context: BrowserContext
+  readonly filterButton: Locator
+
+  constructor(page: Page, context: BrowserContext) {
+    this.page = page
+    this.context = context
+    this.filterButton = page.locator('text=Log In')
+  }
+
+  async gotoAndSortBy(
+    cmsSection: string,
+    field = 'updatedAt',
+    order: 'asc' | 'desc' = 'desc'
+  ) {
+    // determine the url sort operator
+    // minus is descending, nothing is ascending
+    const orderOperator = order == 'desc' ? '-' : ''
+    // build the url for the page with the sortBy set
+    const url = `http://localhost:3001/${cmsSection}?sortBy=${orderOperator}${field}`
+    // Go to the url
+    await this.page.goto(url)
+    // ensure we got there
+    await expect(this.page).toHaveURL(url)
+  }
+}


### PR DESCRIPTION
# SC-1394

## Proposed changes

Adds an e2e helper `gotoAndSortBy` that will go to a CMS page after adding the `sortBy` query parameters to sort the data as needed by the test to locate its data.

## Reviewer notes

We only hit an issue once the page with the list has more than 50 items causing it to appear on page two.

NOTE: this PR is based on #187 so it includes that test too

## Setup

Run the tests

```sh
yarn services:up -d
yarn wait-on http://localhost:3000/api/sysinfo http://localhost:3001/api/sysinfo && yarn e2e:test
```

If you want to create a bunch of data mare one of the tests that creates an article or event with `.only` and then run, assuming `yarn services:up -d` is still running

```sh
for i in {1..50}; do yarn e2e:test; done
```