### PR TITLE
test: Add test for embedding video in an article

### DIFF
--- a/e2e/playwright/feature/article-embed-video.spec.ts
+++ b/e2e/playwright/feature/article-embed-video.spec.ts
@@ -1,0 +1,66 @@
+import { test as base } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  fixtures,
+  TestingLibraryFixtures,
+} from '@playwright-testing-library/test/fixture'
+import { adminUser } from '../cms/database/users'
+import { LoginPage } from '../models/Login'
+import { KeystoneArticlePage } from '../models/KeystoneArticle'
+
+type CustomFixtures = {
+  loginPage: LoginPage
+  keystoneArticlePage: KeystoneArticlePage
+}
+
+const test = base.extend<TestingLibraryFixtures & CustomFixtures>({
+  ...fixtures,
+  loginPage: async ({ page, context }, use) => {
+    await use(new LoginPage(page, context))
+  },
+  keystoneArticlePage: async ({ page, context }, use) => {
+    await use(new KeystoneArticlePage(page, context))
+  },
+})
+
+const { expect } = test
+
+test('can create an article with an embedded video', async ({
+  page,
+  loginPage,
+  keystoneArticlePage,
+}) => {
+  await loginPage.login(adminUser.username, adminUser.password)
+  await expect(page.locator('text=WELCOME, FLOYD KING')).toBeVisible()
+
+  await page.goto('http://localhost:3001')
+  await expect(
+    page.locator('text=Signed in as FLOYD.KING.376144527@testusers.cce.af.mil')
+  ).toBeVisible()
+
+  /* Navigate to the Articles page */
+  await Promise.all([
+    page.waitForNavigation(),
+    page.locator('h3:has-text("Articles")').click(),
+  ])
+
+  const title = faker.lorem.words()
+  const slug = faker.helpers.slugify(title)
+  const videoLink = 'https://youtu.be/dh4uUt3Bbjs'
+
+  // Create article
+  await keystoneArticlePage.createInternalNewsArticle({
+    title,
+    slug,
+    videoLink,
+  })
+
+  // Go to portal to view article
+  await page.goto(`http://localhost:3000/articles/${slug}`)
+  await expect(page.locator(`text=${title}`)).toBeVisible()
+
+  await expect(page.locator(`text=${title}`)).toBeVisible()
+  await expect(
+    page.frameLocator('iframe').locator('[aria-label="Play"]')
+  ).toBeVisible()
+})

--- a/e2e/playwright/feature/article-embed-video.spec.ts
+++ b/e2e/playwright/feature/article-embed-video.spec.ts
@@ -59,8 +59,14 @@ test('can create an article with an embedded video', async ({
   await page.goto(`http://localhost:3000/articles/${slug}`)
   await expect(page.locator(`text=${title}`)).toBeVisible()
 
-  await expect(page.locator(`text=${title}`)).toBeVisible()
   await expect(
     page.frameLocator('iframe').locator('[aria-label="Play"]')
   ).toBeVisible()
+
+  // We want to check that the embed IDs match
+  const embedId = (await page.locator('iframe').getAttribute('src'))?.split(
+    '/embed/'
+  )[1]
+  const videoLinkId = videoLink.split('/')[3]
+  expect(embedId).toBe(videoLinkId)
 })

--- a/e2e/playwright/models/KeystoneArticle.ts
+++ b/e2e/playwright/models/KeystoneArticle.ts
@@ -42,7 +42,7 @@ export class KeystoneArticlePage {
       // They are in a consistent order due to the current structure of the Article schema. The 4th one is the
       // '+' in the body field that opens a dropdown where the user can select the 'Embed Video' option.
       await this.page.locator('[aria-haspopup="true"] >> nth=4').click()
-      await this.page.locator('text=Embed Video').click()
+      await this.page.locator('text=Embed YouTube Video').click()
       await this.page.locator('button >> text=Edit').click()
       // Same as the above comment, there is a consistent order of input fields due to the structure
       // of the Article schema. The 4th and 5th are for adding a video title and the link for the video, respectively.

--- a/e2e/playwright/models/KeystoneArticle.ts
+++ b/e2e/playwright/models/KeystoneArticle.ts
@@ -24,7 +24,7 @@ export class KeystoneArticlePage {
     title,
     category = 'O',
     preview = undefined,
-    videoLink = '',
+    videoLink = undefined,
   }: ArticleFields) {
     await this.page.locator('label[for="category"]').click()
     await this.page.keyboard.type(category)

--- a/e2e/playwright/models/KeystoneArticle.ts
+++ b/e2e/playwright/models/KeystoneArticle.ts
@@ -38,8 +38,8 @@ export class KeystoneArticlePage {
     await this.page.locator('#preview').fill(previewData)
 
     if (videoLink) {
-      // As of writing this test, there are only 9 elements on the article creation page. They are
-      // in a consistent order due to the current structure of the Article schema. The 4th one is the
+      // As of writing this test, there are only 9 elements with the aria-haspopup attribute on the article creation page.
+      // They are in a consistent order due to the current structure of the Article schema. The 4th one is the
       // '+' in the body field that opens a dropdown where the user can select the 'Embed Video' option.
       await this.page.locator('[aria-haspopup="true"] >> nth=4').click()
       await this.page.locator('text=Embed Video').click()

--- a/e2e/playwright/models/KeystoneArticle.ts
+++ b/e2e/playwright/models/KeystoneArticle.ts
@@ -7,8 +7,8 @@ type ArticleFields = {
   category?: string
   slug?: string
   preview?: string
+  videoLink?: string
 }
-
 
 export class KeystoneArticlePage {
   readonly page: Page
@@ -24,6 +24,7 @@ export class KeystoneArticlePage {
     title,
     category = 'O',
     preview = undefined,
+    videoLink = '',
   }: ArticleFields) {
     await this.page.locator('label[for="category"]').click()
     await this.page.keyboard.type(category)
@@ -35,6 +36,20 @@ export class KeystoneArticlePage {
     await this.page.locator('#title').fill(`${title}`)
     const previewData = preview ? preview : faker.lorem.words(20)
     await this.page.locator('#preview').fill(previewData)
+
+    if (videoLink) {
+      // As of writing this test, there are only 9 elements on the article creation page. They are
+      // in a consistent order due to the current structure of the Article schema. The 4th one is the
+      // '+' in the body field that opens a dropdown where the user can select the 'Embed Video' option.
+      await this.page.locator('[aria-haspopup="true"] >> nth=4').click()
+      await this.page.locator('text=Embed Video').click()
+      await this.page.locator('button >> text=Edit').click()
+      // Same as the above comment, there is a consistent order of input fields due to the structure
+      // of the Article schema. The 4th and 5th are for adding a video title and the link for the video, respectively.
+      await this.page.locator('input >> nth=4').fill('My Test Video Title')
+      await this.page.locator('input >> nth=5').fill(videoLink)
+      await this.page.locator('text=Done').click()
+    }
   }
 
   async fillInternalNewsArticleFields(articleFields: ArticleFields) {
@@ -69,16 +84,16 @@ export class KeystoneArticlePage {
   }
 
   nthNumber(number: number) {
-    if (number > 3 && number < 21) return "th";
+    if (number > 3 && number < 21) return 'th'
     switch (number % 10) {
       case 1:
-        return "st";
+        return 'st'
       case 2:
-        return "nd";
+        return 'nd'
       case 3:
-        return "rd";
+        return 'rd'
       default:
-        return "th";
+        return 'th'
     }
   }
 
@@ -89,16 +104,26 @@ export class KeystoneArticlePage {
       await expect(this.page.locator('.rdp')).toBeVisible()
       // If the current month isn't what was passed in assume it's the next one
       // not handling dates in the past since that's not the happy path but we may need to at somepoint
-      if (await this.page.locator(`h2:has-text("${publishedDate.toFormat("MMMM yyyy")}")`).isHidden()) {
+      if (
+        await this.page
+          .locator(`h2:has-text("${publishedDate.toFormat('MMMM yyyy')}")`)
+          .isHidden()
+      ) {
         await this.page.locator('[aria-label="Go to next month"]').click()
       }
       // Keystone labels the calendar buttons 1010th February for some reason
       // So using `nth=0` guarantees we find 4th February instead of 4th, 14th, and 24th.
       const dateFormat = `d'${this.nthNumber(publishedDate.day)}' MMMM`
-      await this.page.locator(`button:has-text("${publishedDate.toFormat(dateFormat)}") >> nth=0`).click()
+      await this.page
+        .locator(
+          `button:has-text("${publishedDate.toFormat(dateFormat)}") >> nth=0`
+        )
+        .click()
       // Wait for the dialog to disappear, otherwise you might not set the time
       await expect(this.page.locator('.rdp')).toBeHidden()
-      await this.page.locator('input[placeholder="00:00"]').fill(publishedDate.toFormat("HH:mm"))
+      await this.page
+        .locator('input[placeholder="00:00"]')
+        .fill(publishedDate.toFormat('HH:mm'))
     }
 
     await this.page.locator('button:has-text("Save changes")').click()


### PR DESCRIPTION
# SC-1540 and SC-1541

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Add test for embedding a YouTube video in an article
<!-- description and/or list of proposed changes -->

## Reviewer notes
If you want to run this locally, be sure to have both the portal and cms on the `jc-investigate-video` branch

CMS PR: https://github.com/USSF-ORBIT/ussf-portal-cms/pull/260/
Portal client PR: https://github.com/USSF-ORBIT/ussf-portal-client/pull/923/
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup
To run locally:
- `yarn services:up -d`
- `yarn e2e:test`
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
