### PR TITLE
test: Support running playwright with multiple browsers

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -99,7 +99,7 @@ jobs:
         run: npx playwright install --with-deps
         working-directory: ./e2e-tests/e2e
 
-      - name: Run Playwright tests
+      - name: Run Playwright tests across all browsers
         # forbid only will fail build if a test has .only on it
         run: yarn playwright test --forbid-only
         working-directory: ./e2e-tests/e2e

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,8 +12,12 @@
     "services:up": "LOCAL_BUILD='-local' docker compose up --build --force-recreate --remove-orphans",
     "services:down": "docker compose down",
     "e2e:install": "yarn --cwd playwright/ install && cd playwright/ && npx playwright install",
-    "e2e:test": "yarn --cwd playwright/ playwright test",
-    "e2e:debug": "PWDEBUG=1 yarn --cwd playwright/ playwright test --headed",
+    "e2e:all": "yarn --cwd playwright/ playwright test --forbid-only",
+    "e2e:test": "yarn --cwd playwright/ playwright test --project feature-chromium --project cms-chromium --project client-chromium",
+    "e2e:debug": "PWDEBUG=1 yarn --cwd playwright/ playwright test --headed --project feature-chromium --project cms-chromium --project client-chromium",
+    "e2e:chrome": "yarn --cwd playwright/ playwright test --project feature-chrome --project cms-chrome --project client-chrome",
+    "e2e:firefox": "yarn --cwd playwright/ playwright test --project feature-firefox --project cms-firefox --project client-firefox",
+    "e2e:msedge": "yarn --cwd playwright/ playwright test --project feature-msedge --project cms-msedge --project client-msedge",
     "e2e:codegen": "yarn --cwd playwright/ playwright codegen localhost:3001"
   },
   "devDependencies": {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,10 +1,28 @@
 import { PlaywrightTestConfig } from '@playwright/test'
 import path from 'path'
 
+const cmsConfig = {
+  use: {
+    baseURL: 'http://localhost:3001',
+  },
+  testDir: 'playwright/cms/tests',
+}
+const clientConfig = {
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  testDir: 'playwright/portal-client/tests',
+}
+const featureConfig = {
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  testDir: 'playwright/feature',
+}
+
 const config: PlaywrightTestConfig = {
   globalSetup: path.resolve('./playwright/global-setup'),
   use: {
-    browserName: 'chromium',
     headless: true,
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -14,26 +32,128 @@ const config: PlaywrightTestConfig = {
   expect: { timeout: 15000 },
   projects: [
     {
-      name: 'CMS E2E',
+      ...cmsConfig,
+      name: 'cms-msedge',
       use: {
-        baseURL: 'http://localhost:3001',
+        ...cmsConfig.use,
+        channel: 'msedge',
       },
-      testDir: 'playwright/cms/tests',
     },
     {
-      name: 'PORTAL CLIENT E2E',
+      ...clientConfig,
+      name: 'client-msedge',
       use: {
-        baseURL: 'http://localhost:3000',
+        ...clientConfig.use,
+        channel: 'msedge',
       },
-      testDir: 'playwright/portal-client/tests',
     },
     {
-      name: 'FEATURES E2E',
+      ...featureConfig,
+      name: 'feature-msedge',
       use: {
-        baseURL: 'http://localhost:3000',
+        ...featureConfig.use,
+        channel: 'msedge',
       },
-      testDir: 'playwright/feature',
     },
+    {
+      ...cmsConfig,
+      name: 'cms-chrome',
+      use: {
+        ...cmsConfig.use,
+        channel: 'chrome',
+      },
+    },
+    {
+      ...clientConfig,
+      name: 'client-chrome',
+      use: {
+        ...clientConfig.use,
+        channel: 'chrome',
+      },
+    },
+    {
+      ...featureConfig,
+      name: 'feature-chrome',
+      use: {
+        ...featureConfig.use,
+        channel: 'chrome',
+      },
+    },
+    {
+      ...cmsConfig,
+      name: 'cms-chromium',
+      use: {
+        ...cmsConfig.use,
+        browserName: 'chromium',
+      },
+    },
+    {
+      ...clientConfig,
+      name: 'client-chromium',
+      use: {
+        ...clientConfig.use,
+        browserName: 'chromium',
+      },
+    },
+    {
+      ...featureConfig,
+      name: 'feature-chromium',
+      use: {
+        ...featureConfig.use,
+        browserName: 'chromium',
+      },
+    },
+    {
+      ...cmsConfig,
+      name: 'cms-firefox',
+      use: {
+        browserName: 'firefox',
+        ...cmsConfig.use,
+      },
+    },
+    {
+      ...clientConfig,
+      name: 'client-firefox',
+      use: {
+        ...clientConfig.use,
+        browserName: 'firefox',
+      },
+    },
+    {
+      ...featureConfig,
+      name: 'feature-firefox',
+      use: {
+        ...featureConfig.use,
+        browserName: 'firefox',
+      },
+    },
+    // TODO: cannot sign into docker e2e services when using web kit
+    // login of the user fails just redirects from login page to the
+    // unauth portal landing page.
+    // {
+    //   ...cmsConfig,
+    //   name: 'cms-webkit',
+    //   use: {
+    //     ...cmsConfig.use,
+    //     browserName: 'webkit',
+    //   },
+    // },
+    // {
+    //   ...clientConfig,
+    //   name: 'client-webkit',
+    //   use: {
+    //     ...clientConfig.use,
+    //     browserName: 'webkit',
+    //   },
+    // },
+    // {
+    //   ...featureConfig,
+    //   name: 'feature-webkit',
+    //   use: {
+    //     ...featureConfig.use,
+    //     browserName: 'webkit',
+    //   },
+    // },
   ],
 }
 


### PR DESCRIPTION
# SC-1557

## Proposed changes

Update playwright configuration to run tests against multiple browsers: Chrome, MS Edge, Firefox, and Chromium during the GitHub action that runs the e2e tests. Local development commands have been updated to only run tests against chromium.

## Reviewer notes

New commands
* `yarn e2e:all` - runs all tests in all browsers. You must have Chrome and MS Edge installed separately. See [playwright browser docs](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge) **NOTE** this command enforces no `.only` flagged tests.
* `yarn e2e:test` - runs all tests against only chromium, should be no difference than before.
* `yarn e2e:chrome` - runs all the tests in chrome
* `yarn e2e:firefox` - runs all the tests in firefox
* `yarn e2e:msedge` - runs all the tests in ms edge

## Setup

Same as usual. Feel free to try the other browsers if you like but note installation of chrome and edge is something you have to do as playwright cannot.

```sh
yarn services:removeall
yarn services:up -d
yarn wait-on http://localhost:3000/api/sysinfo http://localhost:3001/api/sysinfo && yarn e2e:test
```