### PR TITLE
test: update firefox timeouts

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -110,6 +110,8 @@ const config: PlaywrightTestConfig = {
         browserName: 'firefox',
         ...cmsConfig.use,
       },
+      timeout: 45000,
+      expect: { timeout: 20000 },
     },
     {
       ...clientConfig,
@@ -118,6 +120,8 @@ const config: PlaywrightTestConfig = {
         ...clientConfig.use,
         browserName: 'firefox',
       },
+      timeout: 45000,
+      expect: { timeout: 20000 },
     },
     {
       ...featureConfig,
@@ -126,6 +130,8 @@ const config: PlaywrightTestConfig = {
         ...featureConfig.use,
         browserName: 'firefox',
       },
+      timeout: 45000,
+      expect: { timeout: 20000 },
     },
     // TODO: cannot sign into docker e2e services when using web kit
     // login of the user fails just redirects from login page to the


### PR DESCRIPTION
Firefox tests seem to take a little longer than other tests bumping the timeouts to have less flakes

## Proposed changes

Increase timeouts for firefox tests

## Reviewer notes

I only increased the FF tests timeout to avoid just a blanket change. Also any real failures will take longer to realize they have failed.

## Setup

```sh
yarn services:removeall
yarn services:up -d
yarn wait-on http://localhost:3000/api/sysinfo http://localhost:3001/api/sysinfo && yarn e2e:firefox
```