### PR TITLE
ci: improve dependency grouping and labeling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,22 +12,25 @@
     {
       "description": "Group minor and patch updates for Node into a single PR",
       "groupName": "node",
-      "matchSourceUrls": ["https://github.com/nodejs/node"],
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchDepNames": ["node"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "lockFileMaintenance": { "enabled": true },
       "labels": ["node"]
     },
     {
       "description": "Group minor and patch updates for devDependencies into a single PR",
       "groupName": "devDependencies (non-major)",
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchUpdateTypes": ["minor", "patch"],
       "labels": ["devDependencies"]
     },
     {
       "description": "Group minor and patch updates for NPM into a single PR",
       "groupName": "dependencies",
       "managers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "lockFileMaintenance": { "enabled": true },
+      "labels": ["npm Dependencies"]
     },
     {
       "managers": ["dockerfile"],
@@ -38,18 +41,19 @@
       "description": "Group minor and patch updates for github-actions into a single PR",
       "groupName": "github-actions",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "labels": ["github-actions"]
     },
     {
       "description": "Group minor and patch updates for docker-compose files into a single PR",
       "groupName": "docker-compose",
       "managers": ["docker-compose"],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["docker-compose"]
     },
     {
       "rebaseWhen": "behind-base-branch",
-      "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "lockFileMaintenance": { "enabled": true },
       "labels": ["dependencies"]
     }


### PR DESCRIPTION
# SC-1619

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

- improve labeling so we know which package rule is executed when a dependency PR is made
- improve Node package rule so hopefully all Node updates are packaged together
- Improve lockfile maintenance on package rules that include Node dependencies
- add `digest` updateType to `github-actions` package rules so hopefully all `github-actions` updates are grouped together
<!-- description and/or list of proposed changes -->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
