### PR TITLE
fix: fixes renovate/node leaving out engine updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,18 +8,22 @@
     "packages:jsUnitTest"
   ],
   "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
-      "description": "Group minor and patch updates for Node into a single PR",
+      "description": "Group updates for Node.js into a single PR",
       "groupName": "node",
-      "matchDepNames": ["node"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "lockFileMaintenance": { "enabled": true },
-      "labels": ["node"]
+      "labels": ["node"],
+      "commitMessageTopic": "Node.js",
+      "matchPackageNames": ["node"],
+      "matchPackagePatterns": ["/node$"]
     },
     {
       "description": "Group minor and patch updates for devDependencies into a single PR",
-      "groupName": "devDependencies (non-major)",
+      "groupName": "devDependencies",
+      "managers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "labels": ["devDependencies"]
@@ -29,7 +33,6 @@
       "groupName": "dependencies",
       "managers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "lockFileMaintenance": { "enabled": true },
       "labels": ["npm Dependencies"]
     },
     {
@@ -54,7 +57,6 @@
     {
       "rebaseWhen": "behind-base-branch",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "lockFileMaintenance": { "enabled": true },
       "labels": ["dependencies"]
     }
   ],


### PR DESCRIPTION
# SC-1619

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- attempts to fix renovate/node branch which does not include engine updates, which when featured in renovate/dependencies branch breaks that branch.
- makes lockfile maintenance true in global config

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
