### PR TITLE
ci: use new portal-client docker-build-cache ECR

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -87,7 +87,7 @@ jobs:
         run: docker compose up -d
         working-directory: ./e2e-tests/e2e
         env:
-          CMS_REPO: ${{ steps.login-ecr.outputs.registry }}
+          CMS_REPO: ${{ steps.login-ecr.outputs.registry }}/keystone
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
 
       - name: Install dependencies

--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -87,8 +87,8 @@ jobs:
         run: docker compose up -d
         working-directory: ./e2e-tests/e2e
         env:
-          CMS_REPO: ${{ steps.login-ecr.outputs.registry }}/keystone
-          PORTAL_REPO: ${{ steps.login-ecr.outputs.registry }}/portal-client
+          CMS_REPO: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -87,7 +87,6 @@ jobs:
         run: docker compose up -d
         working-directory: ./e2e-tests/e2e
         env:
-          CMS_REPO: ${{ steps.login-ecr.outputs.registry }}/keystone
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
 
       - name: Install dependencies

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       dockerfile: Dockerfile
       target: e2e
       cache_from:
-        - '${PORTAL_REPO}:builder'
-        - '${PORTAL_REPO}:e2e'
+        - '${ECR_REGISTRY}/docker-build-cache:portal-client-builder'
+        - '${ECR_REGISTRY}/docker-build-cache:portal-client-e2e'
     restart: always
     ports:
       - '3000:3000'

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       dockerfile: Dockerfile
       target: 'e2e${LOCAL_BUILD}'
       cache_from:
-        - '${CMS_REPO}:builder'
-        - '${CMS_REPO}:e2e'
+        - '${ECR_REGISTRY}/docker-build-cache:keystone-builder'
+        - '${ECR_REGISTRY}/docker-build-cache:keystone-e2e'
     restart: always
     ports:
       - '3001:3001'


### PR DESCRIPTION
# SC-1013

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- Change the docker repository `cache-from` source to a new ECR repository named `docker-build-cache` which will be a dedicated repository for CMS and Client image build caches
- This will improve our build process during E2E tests because there is a higher chance that we have a cache hit because the ECR repo will be less likely to recycle our image caches
- This will improve our ECR's reliability and costs because we can use better written ECR Lifecycle Policies when the image tags are more predictable and there is a different repo for different functions.


## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->
There is a successful workflow dispatch of the E2E tests with the new ECR `cache-from` source here: https://github.com/USSF-ORBIT/ussf-portal/actions/runs/4767039781/jobs/8474809737


## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
