### PR TITLE
ci: build docker images once and share artifact with parallel jobs

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -7,11 +7,99 @@ permissions:
   id-token: write
   contents: read
 jobs:
+  # builds docker images once and saves them as artifacts for parallel e2e job to use
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone portal client  # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+        with:
+          repository: USSF-ORBIT/ussf-portal-client
+          path: ./ussf-portal-client
+          fetch-depth: 0 # fetch all branch information, needed to checkout the branch if present later
+
+      - name: Checkout portal client ${{github.head_ref}} or main
+        if: (github.event_name == 'push' || github.event_name == 'pull_request') && !startsWith(github.head_ref, 'renovate')
+        working-directory: ./ussf-portal-client
+        run: |
+          # checkout the branch that started this pull request or stay on main if no such branch
+          /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
+
+      - name: Clone cms  # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+        with:
+          repository: USSF-ORBIT/ussf-portal-cms
+          path: ./ussf-portal-cms
+          fetch-depth: 0 # fetch all branch information, needed to checkout the branch if present later
+
+      - name: Checkout cms ${{github.head_ref}} or main
+        if: (github.event_name == 'push' || github.event_name == 'pull_request') && !startsWith(github.head_ref, 'renovate')
+        working-directory: ./ussf-portal-cms
+        run: |
+          # checkout the branch that started this pull request or stay on main if no such branch
+          /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2
+        with:
+          aws-access-key-id: ${{ secrets.GHA_ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GHA_ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.GHA_ECR_ROLE_ASSUMPTION }}
+          role-skip-session-tagging: true
+          role-duration-seconds: "3600"
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1
+
+      - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2
+        id: buildx
+        with:
+          install: true
+
+      - name: Build Keystone to e2e Stage
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
+        with:
+          context: ./ussf-portal-cms
+          tags: keystone-cms:e2e
+          cache-to: type=inline
+          outputs: type=docker,dest=/tmp/keystone-cms-e2e.tar
+          target: e2e
+          cache-from: |
+            ${{ steps.login-ecr.outputs.registry }}/docker-build-cache:keystone-builder
+            ${{ steps.login-ecr.outputs.registry }}/docker-build-cache:keystone-e2e
+
+      - name: Build Portal to e2e State
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
+        with:
+          context: ./ussf-portal-client
+          tags: portal-client:e2e
+          cache-to: type=inline
+          outputs: type=docker,dest=/tmp/portal-client-e2e.tar
+          target: e2e
+          cache-from: |
+            ${{ steps.login-ecr.outputs.registry }}/docker-build-cache:portal-client-builder
+            ${{ steps.login-ecr.outputs.registry }}/docker-build-cache:portal-client-e2e
+
+      - name: Upload keystone-cms-e2e
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        with:
+          name: keystone-cms-e2e
+          path: /tmp/keystone-cms-e2e.tar
+
+      - name: Upload portal-client-e2e.tar
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        with:
+          name: portal-client-e2e
+          path: /tmp/portal-client-e2e.tar
+  # run e2e tests on each browser, using build artifacts from the build job
   run-e2e-tests:
     strategy:
       matrix:
         browser: ["chromium", "firefox", "chrome", "msedge"]
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Clone E2E tests repo # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
@@ -64,30 +152,32 @@ jobs:
         with:
           node-version: ${{ steps.engines.outputs.nodeVersion }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2
-        with:
-          aws-access-key-id: ${{ secrets.GHA_ECR_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.GHA_ECR_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.GHA_ECR_ROLE_ASSUMPTION }}
-          role-skip-session-tagging: true
-          role-duration-seconds: "3600"
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1
-
       - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2
         id: buildx
         with:
           install: true
-          
+
+      - name: Download keystone-cms-builder
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        with:
+          name: keystone-cms-e2e
+          path: /tmp
+
+      - name: Download portal-client-e2e.tar
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        with:
+          name: portal-client-e2e
+          path: /tmp
+
+      - name: Load images
+        run: |
+          docker load --input /tmp/keystone-cms-e2e.tar
+          docker load --input /tmp/portal-client-e2e.tar
+          docker image ls -a
+
       - name: Docker compose
         run: docker compose up -d
         working-directory: ./e2e-tests/e2e
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -3,13 +3,14 @@ services:
   # Portal client
   client:
     container_name: client
+    image: portal-client:e2e
     build:
       context: ../../ussf-portal-client/
       dockerfile: Dockerfile
       target: e2e
       cache_from:
-        - '${ECR_REGISTRY}/docker-build-cache:portal-client-builder'
-        - '${ECR_REGISTRY}/docker-build-cache:portal-client-e2e'
+        - 'portal-client:builder'
+        - 'portal-client:e2e'
     restart: always
     ports:
       - '3000:3000'
@@ -35,14 +36,14 @@ services:
 
   cms:
     container_name: keystone-cms
+    image: keystone-cms:e2e
     build:
       context: ../../ussf-portal-cms/
       dockerfile: Dockerfile
       target: 'e2e${LOCAL_BUILD}'
       cache_from:
-        - '${ECR_REGISTRY}/docker-build-cache:keystone-builder'
-        - '${ECR_REGISTRY}/docker-build-cache:keystone-e2e'
-    restart: always
+        - 'keystone-cms:builder'
+        - 'keystone-cms:e2e'
     ports:
       - '3001:3001'
     environment:


### PR DESCRIPTION
# SC-1947

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- adds a job before e2e tests to build portal-client and keystone-cms docker images and save the built images as artifacts. This can be seen in this [completed build job](https://github.com/USSF-ORBIT/ussf-portal/actions/runs/4875463241/jobs/8698258867?pr=269).
- downloads image artifacts in e2e job and loads them into docker,  so `docker compose` can use those images

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

These changes will save us AWS costs as the workflow will only need to pull from AWS ECR a single time rather than four times. There will be future iterative improvements but this is a good step.

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
