### PR TITLE
chore: allow admins to bypass restrictions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -168,7 +168,7 @@ branches:
             "lint-e2e-tests"
           ]
       # Required. Allow owners to by pass restrictions for PRs that are just release notes or github settings changes which do not affect tests
-      # Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      # Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators.
       enforce_admins: false
       # Commits pushed to matching branches must have verified signatures. Set to false to disable.
       required_signatures: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -159,9 +159,17 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["check-e2e-tests / run-e2e-tests (chromium)", "check-e2e-tests / run-e2e-tests (chrome)",check-e2e-tests / run-e2e-tests (firefox)",check-e2e-tests / run-e2e-tests (msedge)", "lint-e2e-tests"]
-      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
+        contexts:
+          [
+            "check-e2e-tests / run-e2e-tests (chromium)",
+            "check-e2e-tests / run-e2e-tests (chrome)",
+            "check-e2e-tests / run-e2e-tests (firefox)",
+            "check-e2e-tests / run-e2e-tests (msedge)",
+            "lint-e2e-tests"
+          ]
+      # Required. Allow owners to by pass restrictions for PRs that are just release notes or github settings changes which do not affect tests
+      # Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: false
       # Commits pushed to matching branches must have verified signatures. Set to false to disable.
       required_signatures: true
       required_linear_history: true


### PR DESCRIPTION
## Proposed changes

Some times our changes don't trigger the build, for example changing documentation or github repo settings. This results in PRs being stuck due to the restrictions. There hasn't been a good way to allow these to be bypassed under certain conditions so we decided to allow admins to be able to bypass the restriction. This should be used sparingly.
