### PR TITLE
test: Change futureDate to 5 weeks

### DIFF
--- a/e2e/playwright/feature/announcement-scheduler.spec.ts
+++ b/e2e/playwright/feature/announcement-scheduler.spec.ts
@@ -49,7 +49,7 @@ test('announcement published with future date cannot be seen', async ({
 
   const title = faker.lorem.words()
 
-  const futureDate = DateTime.now().plus({ weeks: 3 })
+  const futureDate = DateTime.now().plus({ weeks: 5 })
 
   // Create announcement
   await page.locator('text=Create Announcement').click()

--- a/e2e/playwright/feature/article-scheduler.spec.ts
+++ b/e2e/playwright/feature/article-scheduler.spec.ts
@@ -56,7 +56,7 @@ test('orbit blog article published with future date cannot be seen', async ({
   const title = faker.lorem.words()
   const slug = faker.helpers.slugify(title)
 
-  const futureDate = DateTime.now().plus({ weeks: 3 })
+  const futureDate = DateTime.now().plus({ weeks: 5 })
 
   // Create article
   await keystoneArticlePage.createOrbitBlogArticle({ title, slug })
@@ -125,7 +125,7 @@ test('internal news article published with future date cannot be seen', async ({
 
   const title = faker.lorem.words()
   const slug = faker.helpers.slugify(title)
-  const futureDate = DateTime.now().plus({ weeks: 3 })
+  const futureDate = DateTime.now().plus({ weeks: 5 })
 
   // Create article
   await keystoneArticlePage.createInternalNewsArticle({ title, slug })


### PR DESCRIPTION
# SC-###

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Change `futureDate` to be 5 weeks
<!-- description and/or list of proposed changes -->

## Reviewer notes
In some of our tests that involved scheduling items in the CMS, we were generating a `futureDate` that was 3 weeks ahead. Since today is June 1st, 3 weeks from now is still June 2023. This was causing an if statement to fail. I changed all futureDates to 5 weeks, so we are guaranteed to go to the next month.
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
