### PR TITLE
disable firefox e2e tests due to repeated flakey runs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -163,7 +163,6 @@ branches:
           [
             "check-e2e-tests / run-e2e-tests (chromium)",
             "check-e2e-tests / run-e2e-tests (chrome)",
-            "check-e2e-tests / run-e2e-tests (firefox)",
             "check-e2e-tests / run-e2e-tests (msedge)",
             "lint-e2e-tests"
           ]

--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -110,7 +110,7 @@ jobs:
   run-e2e-tests:
     strategy:
       matrix:
-        browser: ["chromium", "firefox", "chrome", "msedge"]
+        browser: [ "chromium", "chrome", "msedge" ]
     runs-on: ubuntu-latest
     needs: get-build-cache
     steps:
@@ -128,7 +128,7 @@ jobs:
           # checkout the branch that started this pull request or stay on main if no such branch
           /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
 
-      - name: Clone portal client  # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
+      - name: Clone portal client # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
         with:
           repository: USSF-ORBIT/ussf-portal-client
@@ -142,7 +142,7 @@ jobs:
           # checkout the branch that started this pull request or stay on main if no such branch
           /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
 
-      - name: Clone cms  # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
+      - name: Clone cms # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
         with:
           repository: USSF-ORBIT/ussf-portal-cms


### PR DESCRIPTION
## Proposed changes

Due to the repeated flakiness of the firefox based e2e tests, and the fact that firefox usage on the portal is less than 3% we are disabling the tests temporarily. In the future we can take a look at stabilizing them before re-enabling them, see SC-2074