### PR TITLE
test: Add drag-and-drop test for collections

### DIFF
--- a/e2e/playwright/feature/drag-and-drop-collections.spec.ts
+++ b/e2e/playwright/feature/drag-and-drop-collections.spec.ts
@@ -1,0 +1,57 @@
+import { test as base } from '@playwright/test'
+import {
+  fixtures,
+  TestingLibraryFixtures,
+} from '@playwright-testing-library/test/fixture'
+
+import { LoginPage } from '../models/Login'
+import { seedDB } from '../portal-client/database/seedMongo'
+import { portalUser1 } from '../cms/database/users'
+type CustomFixtures = {
+  loginPage: LoginPage
+}
+
+const test = base.extend<TestingLibraryFixtures & CustomFixtures>({
+  ...fixtures,
+  loginPage: async ({ page, context }, use) => {
+    await use(new LoginPage(page, context))
+  },
+})
+
+const { describe, expect } = test
+
+test.beforeAll(async () => {
+  await seedDB()
+})
+
+describe('Drag and drop user collections', () => {
+  test('can use the keyboard to drag and drop a collection', async ({
+    page,
+    loginPage,
+  }) => {
+    // Login and check that user is in My Space
+    await loginPage.login(portalUser1.username, portalUser1.password)
+    await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
+    await expect(page.locator('text=Example Collection')).toBeVisible()
+
+    // Add a new collection
+    await page.getByRole('button', { name: 'Add widget' }).click()
+    await page.getByRole('button', { name: 'Create new collection' }).click()
+    await page.getByTestId('textInput').fill('My Custom Collection')
+    await page.getByRole('button', { name: 'Save name' }).click()
+
+    // Drag and drop the new collection
+    const collectionToDrag = page.getByRole('button', {
+      name: 'My Custom Collection Collection Settings + Add link',
+    })
+
+    await collectionToDrag.focus()
+    await page.keyboard.press(' ')
+    await page.keyboard.press('ArrowLeft')
+    await page.keyboard.press('ArrowLeft')
+    await page.keyboard.press(' ')
+
+    // First h3 should be the new collection
+    await expect(page.locator('h3').first()).toHaveText('My Custom Collection')
+  })
+})


### PR DESCRIPTION
# SC-651

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Add test for dragging and dropping collections: https://github.com/USSF-ORBIT/ussf-portal-client/pull/1056
<!-- description and/or list of proposed changes -->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
