### PR TITLE
chore: update test to make search filter test more specific to the seach filter fieldset

### DIFF
--- a/e2e/playwright/feature/search-filter.spec.ts
+++ b/e2e/playwright/feature/search-filter.spec.ts
@@ -71,7 +71,7 @@ describe('Filter search results', () => {
     await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
 
     await page.goto('http://localhost:3000/search')
-    await page.getByText('Application').click()
+    await page.getByTestId('fieldset').getByText('Application').click()
     await page.getByRole('button', { name: 'Filter' }).click()
     await expect(
       page.getByRole('link', { name: 'MyVector (opens in a new window)' })


### PR DESCRIPTION
# SC-2171

required for https://github.com/USSF-ORBIT/ussf-portal-client/pull/1081 to merge


## Proposed changes

adjusts search filter test to have more specificity to target with fieldset so it doesn't hit the Sites  & Applications in the footer

## Reviewer notes

paired with Abigail to figure out what needed to change in the test, the test on my branch was failing because the test was grabbing the footer instead of the search filter.


