### PR TITLE
fix: Add weekday name to button text match

### DIFF
--- a/e2e/playwright/models/KeystoneAnnouncement.ts
+++ b/e2e/playwright/models/KeystoneAnnouncement.ts
@@ -42,7 +42,9 @@ export class KeystoneAnnouncementPage {
       }
       // Keystone labels the calendar buttons 1010th February for some reason
       // So using `nth=0` guarantees we find 4th February instead of 4th, 14th, and 24th.
-      const dateFormat = `d'${this.nthNumber(publishedDate.day)}' MMMM`
+      const dateFormat = `d'${this.nthNumber(publishedDate.day)}' MMMM ('${
+        publishedDate.weekdayLong
+      }')`
       await this.page
         .locator(
           `button:has-text("${publishedDate.toFormat(dateFormat)}") >> nth=0`

--- a/e2e/playwright/models/KeystoneArticle.ts
+++ b/e2e/playwright/models/KeystoneArticle.ts
@@ -129,7 +129,10 @@ export class KeystoneArticlePage {
       }
       // Keystone labels the calendar buttons 1010th February for some reason
       // So using `nth=0` guarantees we find 4th February instead of 4th, 14th, and 24th.
-      const dateFormat = `d'${this.nthNumber(publishedDate.day)}' MMMM`
+      const dateFormat = `dd'${this.nthNumber(publishedDate.day)}' MMMM ('${
+        publishedDate.weekdayLong
+      }')`
+
       await this.page
         .locator(
           `button:has-text("${publishedDate.toFormat(dateFormat)}") >> nth=0`


### PR DESCRIPTION
# SC-xxx

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

Adds another layer of specificity to finding and selecting publish date from calendar. 


## Reviewer notes

Today's date, August 22nd, 2023, revealed a fun edge case where Playwright was matching and selecting August 2 instead. This caused an error since you can't schedule an article in the past.

This is due to how Keystone renders the datepicker in HTML:

<img width="408" alt="Screenshot 2023-08-22 at 2 18 50 PM" src="https://github.com/USSF-ORBIT/ussf-portal/assets/6007259/3ace6fc0-6436-45ee-8f8f-a9ea438bcce0">

<img width="403" alt="Screenshot 2023-08-22 at 2 19 01 PM" src="https://github.com/USSF-ORBIT/ussf-portal/assets/6007259/7f69f2d0-afc5-4471-a094-e1f33e29b263">






## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
