### PR TITLE
chore: Add try catch around possible weather api failure [WIP]

### DIFF
--- a/e2e/playwright/feature/weather-widget.spec.ts
+++ b/e2e/playwright/feature/weather-widget.spec.ts
@@ -34,7 +34,14 @@ test('can add/remove Weather widget to My Space', async ({
 
   await page.getByRole('button', { name: 'Save zip code' }).click()
 
-  await expect(page.locator('text=Beverly Hills, CA')).toBeVisible()
+  try {
+    await expect(page.locator('text=Beverly Hills, CA')).toBeVisible()
+  } catch (err) {
+    expect(async () => {
+      await page.getByRole('button', { name: 'Retry' }).click()
+      await expect(page.locator('text=Beverly Hills, CA')).toBeVisible()
+    }).toPass()
+  }
 
   // Edit Weather widget
   await page
@@ -48,7 +55,14 @@ test('can add/remove Weather widget to My Space', async ({
 
   await page.getByRole('button', { name: 'Save zip code' }).click()
 
-  await expect(page.locator('text=Tempe, AZ')).toBeVisible()
+  try {
+    await expect(page.locator('text=Tempe, AZ')).toBeVisible()
+  } catch (err) {
+    expect(async () => {
+      await page.getByRole('button', { name: 'Retry' }).click()
+      await expect(page.locator('text=Tempe, AZ')).toBeVisible()
+    }).toPass()
+  }
 
   // Remove Weather widget
   await page
@@ -83,7 +97,14 @@ test('can only add five Weather widgets', async ({ page, loginPage }) => {
 
   await page.getByRole('button', { name: 'Save zip code' }).click()
 
-  await expect(page.locator('text=Beverly Hills, CA')).toBeVisible()
+  try {
+    await expect(page.locator('text=Beverly Hills, CA')).toBeVisible()
+  } catch (err) {
+    expect(async () => {
+      await page.getByRole('button', { name: 'Retry' }).click()
+      await expect(page.locator('text=Beverly Hills, CA')).toBeVisible()
+    }).toPass()
+  }
 
   // Add Weather widget
   await page.getByRole('button', { name: 'Add widget' }).click()
@@ -92,7 +113,14 @@ test('can only add five Weather widgets', async ({ page, loginPage }) => {
 
   await page.getByRole('button', { name: 'Save zip code' }).click()
 
-  await expect(page.locator('text=Tempe, AZ')).toBeVisible()
+  try {
+    await expect(page.locator('text=Tempe, AZ')).toBeVisible()
+  } catch (err) {
+    expect(async () => {
+      await page.getByRole('button', { name: 'Retry' }).click()
+      await expect(page.locator('text=Tempe, AZ')).toBeVisible()
+    }).toPass()
+  }
 
   // Add Weather widget
   await page.getByRole('button', { name: 'Add widget' }).click()
@@ -101,7 +129,14 @@ test('can only add five Weather widgets', async ({ page, loginPage }) => {
 
   await page.getByRole('button', { name: 'Save zip code' }).click()
 
-  await expect(page.locator('text=Guadalupe, AZ')).toBeVisible()
+  try {
+    await expect(page.locator('text=Guadalupe, AZ')).toBeVisible()
+  } catch (err) {
+    expect(async () => {
+      await page.getByRole('button', { name: 'Retry' }).click()
+      await expect(page.locator('Guadalupe, AZ')).toBeVisible()
+    }).toPass()
+  }
 
   // Add Weather widget
   await page.getByRole('button', { name: 'Add widget' }).click()
@@ -110,7 +145,14 @@ test('can only add five Weather widgets', async ({ page, loginPage }) => {
 
   await page.getByRole('button', { name: 'Save zip code' }).click()
 
-  await expect(page.locator('text=Atlanta, GA')).toBeVisible()
+  try {
+    await expect(page.locator('text=Atlanta, GA')).toBeVisible()
+  } catch (err) {
+    expect(async () => {
+      await page.getByRole('button', { name: 'Retry' }).click()
+      await expect(page.locator('text=Atlanta, GA')).toBeVisible()
+    }).toPass()
+  }
 
   // Add Weather widget
   await page.getByRole('button', { name: 'Add widget' }).click()
@@ -119,7 +161,14 @@ test('can only add five Weather widgets', async ({ page, loginPage }) => {
 
   await page.getByRole('button', { name: 'Save zip code' }).click()
 
-  await expect(page.locator('text=Chicago, IL')).toBeVisible()
+  try {
+    await expect(page.locator('text=Chicago, IL')).toBeVisible()
+  } catch (err) {
+    expect(async () => {
+      await page.getByRole('button', { name: 'Retry' }).click()
+      await expect(page.locator('text=Chicago, IL')).toBeVisible()
+    }).toPass()
+  }
 
   // Check that Add Weather widget button is disabled
   await page.getByRole('button', { name: 'Add widget' }).click()


### PR DESCRIPTION
# SC-1604

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
The PR is an attempt to fix flaky weather widget tests until we can add a mock service and avoid querying the third-party API directly.

Related PR: https://github.com/USSF-ORBIT/ussf-portal-client/pull/1105

## Reviewer notes
The current state is using a try/catch around adding the weather widget, and wrapping additional logic in  `expect(...).toPass()` -- this should allow that portion of the test to repeat until it gets a successful response. This seemed to work for me, but a) it might not be the final fix, and b) there may be other issues that still need to be debugged.
## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
