### PR TITLE
chore: save disk space pruning unused  docker images

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -185,7 +185,10 @@ jobs:
           key: ${{ runner.os }}-docker-keystone-cms-${{ needs.get-build-cache.outputs.keystone-cms-docker-tag }}
 
       - name: Docker compose
-        run: docker compose up -d
+        run: |
+            docker image prune --all --force
+            docker compose up -d
+            docker builder prune --all --force
         working-directory: ./e2e-tests/e2e
 
       - name: Install dependencies

--- a/e2e/playwright/feature/announcement-scheduler.spec.ts
+++ b/e2e/playwright/feature/announcement-scheduler.spec.ts
@@ -62,10 +62,11 @@ test('announcement published with future date cannot be seen', async ({
     publishedDate: futureDate,
   })
 
-  // Check that the announcement has the proper date
+  // Check that the button has the correct date
   await expect(
-    page.locator(`text=${futureDate.toFormat('MM/dd/yyyy')}`)
+    page.locator(`button:has-text("${futureDate.toFormat('MM/dd/yyyy')}")`)
   ).toBeVisible()
+
   await expect(page.locator(`input[placeholder="00:00"]`)).toHaveValue(
     futureDate.toFormat('HH:mm')
   )

--- a/e2e/playwright/feature/article-scheduler.spec.ts
+++ b/e2e/playwright/feature/article-scheduler.spec.ts
@@ -68,7 +68,7 @@ test('orbit blog article published with future date cannot be seen', async ({
 
   // check that the article has the date
   await expect(
-    page.locator(`text=${futureDate.toFormat('MM/dd/yyyy')}`)
+    page.locator(`button:has-text("${futureDate.toFormat('MM/dd/yyyy')}")`)
   ).toBeVisible()
   await expect(page.locator(`input[placeholder="00:00"]`)).toHaveValue(
     futureDate.toFormat('HH:mm')
@@ -137,7 +137,7 @@ test('internal news article published with future date cannot be seen', async ({
 
   // check that the article has the date
   await expect(
-    page.locator(`text=${futureDate.toFormat('MM/dd/yyyy')}`)
+    page.locator(`button:has-text("${futureDate.toFormat('MM/dd/yyyy')}")`)
   ).toBeVisible()
   await expect(page.locator(`input[placeholder="00:00"]`)).toHaveValue(
     futureDate.toFormat('HH:mm')


### PR DESCRIPTION
<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

It appears that we are coming close to the limit of free space allocated on the default Github Actions Runners. Because of our multi-stage builds, multiple repos checked out, and dependencies that have to install on the runner we need to create more disk space on the Runner. This PR should save us a considerable amount if space with a small amount of time.

## Proposed changes

<!-- description and/or list of proposed changes -->
- Prune unused docker images that came built-into the GHA runner
- Prune docker build cache after `docker compose` as we don't need it after the build
- Update locator to only look at button in E2E tests

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
