### PR TITLE
test: guardian directory

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -102,9 +102,56 @@ jobs:
         with:
           path: /tmp/keystone-cms
           key: ${{ runner.os }}-docker-keystone-cms-${{ steps.keystone_manifest.outputs.keystone_cms_docker_tag }}
+
+      - name: Download personnel-api image manifest
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2
+        with:
+          github_token: ${{secrets.ACTION_DOWNLOAD_ARTIFACT_GITHUB_TOKEN}}
+          workflow: build-docker-cache-artifacts.yml
+          workflow_conclusion: success
+          branch: main
+          name: personnel-api-index
+          path: /tmp/portal-manifest
+          repo: USSF-ORBIT/ussf-personnel-api
+          if_no_artifact_found: warn
+
+      - name: Get docker image digest from personnel-api manifest
+        id: portal_manifest
+        run: |
+          digest=$(cat /tmp/portal-manifest/index.json | jq -r '.manifests[0].digest')
+          echo "personnel_api_docker_tag=${digest##sha256:}" >> $GITHUB_OUTPUT
+
+      - name: Lookup if personnel-api image build cache is available
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
+        id: restore-client-cache
+        with:
+          path: /tmp/personnel-api
+          key: ${{ runner.os }}-docker-personnel-api-${{ steps.portal_manifest.outputs.personnel_api_docker_tag }}
+          lookup-only: true
+
+      - name: If personnel-api build cache not found locally, download personnel-api build cache
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2
+        if: steps.restore-client-cache.outputs.cache-hit != 'true'
+        with:
+          github_token: ${{secrets.ACTION_DOWNLOAD_ARTIFACT_GITHUB_TOKEN}}
+          workflow: build-docker-cache-artifacts.yml
+          workflow_conclusion: success
+          branch: main
+          name: personnel-api
+          path: /tmp/personnel-api
+          repo: USSF-ORBIT/ussf-personnel-api
+          if_no_artifact_found: warn
+
+      - name: If personnel-api build cache not found locally, save it to this repo's GHA cache
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
+        if: steps.restore-client-cache.outputs.cache-hit != 'true'
+        with:
+          path: /tmp/personnel-api
+          key: ${{ runner.os }}-docker-personnel-api-${{ steps.portal_manifest.outputs.personnel_api_docker_tag }}
     outputs:
       keystone-cms-docker-tag: ${{ steps.keystone_manifest.outputs.keystone_cms_docker_tag }}
       portal-client-docker-tag: ${{ steps.portal_manifest.outputs.portal_client_docker_tag }}
+      personnel-api-docker-tag: ${{ steps.portal_manifest.outputs.personnel_api_docker_tag }}
 
   # run e2e tests on each browser, using build artifacts from the build job
   run-e2e-tests:
@@ -152,6 +199,20 @@ jobs:
       - name: Checkout cms ${{github.head_ref}} or main
         if: (github.event_name == 'push' || github.event_name == 'pull_request') && !startsWith(github.head_ref, 'renovate')
         working-directory: ./ussf-portal-cms
+        run: |
+          # checkout the branch that started this pull request or stay on main if no such branch
+          /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
+
+      - name: Clone personnel api # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+        with:
+          repository: USSF-ORBIT/ussf-personnel-api
+          path: ./ussf-personnel-api
+          fetch-depth: 0 # fetch all branch information, needed to checkout the branch if present later
+
+      - name: Checkout personnel api ${{github.head_ref}} or main
+        if: (github.event_name == 'push' || github.event_name == 'pull_request') && !startsWith(github.head_ref, 'renovate')
+        working-directory: ./ussf-personnel-api
         run: |
           # checkout the branch that started this pull request or stay on main if no such branch
           /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -81,9 +81,7 @@ services:
   personnel-api:
     container_name: personnel-api
     build:
-      # Uncomment the below line to work with local check out
-      # context: ../ussf-personnel-api/
-      context: https://github.com/USSF-ORBIT/ussf-personnel-api.git#main
+      context: ../../ussf-personnel-api/
       dockerfile: Dockerfile
       target: builder
     restart: always

--- a/e2e/playwright/feature/guardian-directory.spec.ts
+++ b/e2e/playwright/feature/guardian-directory.spec.ts
@@ -1,0 +1,92 @@
+import { test as base } from '@playwright/test'
+import {
+  fixtures,
+  TestingLibraryFixtures,
+} from '@playwright-testing-library/test/fixture'
+import { portalUser1 } from '../cms/database/users'
+import { LoginPage } from '../models/Login'
+
+type CustomFixtures = {
+  loginPage: LoginPage
+}
+
+const test = base.extend<TestingLibraryFixtures & CustomFixtures>({
+  ...fixtures,
+  loginPage: async ({ page, context }, use) => {
+    await use(new LoginPage(page, context))
+  },
+})
+
+const { expect } = test
+
+test('can view the guardian directory', async ({
+  page,
+  loginPage,
+}) => {
+  // Log in as CMS admin
+  await loginPage.login(portalUser1.username, portalUser1.password)
+
+  await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
+  await page.locator('text=Guardian Directory').click()
+  await expect(
+    page.getByRole('heading', { name: 'Guardian Directory' })
+  ).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'First Name' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Last Name' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Rank' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Title' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Base' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Field Commands' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Email' })).toBeVisible()
+
+  // wait for data to show
+  await page.locator('[data-testid="guardian-directory-table"] tbody tr').first().waitFor();
+
+  // check first row
+  await expect(page.getByTestId('0_FirstName')).toBeVisible()
+  await expect(page.getByTestId('0_FirstName')).toHaveText("Ronald")
+  await expect(page.getByTestId('0_LastName')).toBeVisible()
+  await expect(page.getByTestId('0_LastName')).toHaveText("Boyd")
+  await expect(page.getByTestId('0_Rank')).toBeVisible()
+  await expect(page.getByTestId('0_Rank')).toHaveText("Spc2/E-2")
+  await expect(page.getByTestId('0_DutyTitle')).toBeVisible()
+  await expect(page.getByTestId('0_DutyTitle')).toHaveText("Engineer")
+  await expect(page.getByTestId('0_BaseLoc')).toBeVisible()
+  await expect(page.getByTestId('0_BaseLoc')).toHaveText("Vandenberg")
+  await expect(page.getByTestId('0_MajCom')).toBeVisible()
+  await expect(page.getByTestId('0_MajCom')).toHaveText("Space Training And Readiness Command (6T)")
+  await expect(page.getByTestId('0_Email')).toBeVisible()
+  await expect(page.getByTestId('0_Email')).toHaveText("ronald.boyd@spaceforce.mil")
+
+  // check last row
+  await expect(page.getByTestId('8_FirstName')).toBeVisible()
+  await expect(page.getByTestId('8_FirstName')).toHaveText("Lindsey")
+  await expect(page.getByTestId('8_LastName')).toBeVisible()
+  await expect(page.getByTestId('8_LastName')).toHaveText("Wilson")
+  await expect(page.getByTestId('8_Rank')).toBeVisible()
+  await expect(page.getByTestId('8_Rank')).toHaveText("Spc3/E-3")
+  await expect(page.getByTestId('8_DutyTitle')).toBeVisible()
+  await expect(page.getByTestId('8_DutyTitle')).toHaveText("Designer")
+  await expect(page.getByTestId('8_BaseLoc')).toBeVisible()
+  await expect(page.getByTestId('8_BaseLoc')).toHaveText("Buckley")
+  await expect(page.getByTestId('8_MajCom')).toBeVisible()
+  await expect(page.getByTestId('8_MajCom')).toHaveText("United States Space Force Forces (6F)")
+  await expect(page.getByTestId('8_Email')).toBeVisible()
+  await expect(page.getByTestId('8_Email')).toHaveText("lindsey.wilson@spaceforce.mil")
+
+  // check an officer
+  await expect(page.getByTestId('5_FirstName')).toBeVisible()
+  await expect(page.getByTestId('5_FirstName')).toHaveText("Ethel")
+  await expect(page.getByTestId('5_LastName')).toBeVisible()
+  await expect(page.getByTestId('5_LastName')).toHaveText("Neal")
+  await expect(page.getByTestId('5_Rank')).toBeVisible()
+  await expect(page.getByTestId('5_Rank')).toHaveText("1st Lt/O-2")
+  await expect(page.getByTestId('5_DutyTitle')).toBeVisible()
+  await expect(page.getByTestId('5_DutyTitle')).toHaveText("Space Combat")
+  await expect(page.getByTestId('5_BaseLoc')).toBeVisible()
+  await expect(page.getByTestId('5_BaseLoc')).toHaveText("Schriever")
+  await expect(page.getByTestId('5_MajCom')).toBeVisible()
+  await expect(page.getByTestId('5_MajCom')).toHaveText("Space Systems Command (6S)")
+  await expect(page.getByTestId('5_Email')).toBeVisible()
+  await expect(page.getByTestId('5_Email')).toHaveText("ethel.neal@spaceforce.mil")
+})


### PR DESCRIPTION
# SC-2303

## Proposed changes

Adds an e2e test for the guardian directory. Also updates it so that the USSF-ORBIT/ussf-personnel-api branch that matches the one in this repo is used for e2e tests if it exists.

## Reviewer notes

## Setup

yarn services:removeall && yarn services:up -d && yarn wait-on http://localhost:3000/api/sysinfo http://localhost:3001/api/sysinfo && yarn e2e:test
