### PR TITLE
ci: add a personal access token to release please

### DIFF
--- a/.github/workflows/reusable-release-please.yml
+++ b/.github/workflows/reusable-release-please.yml
@@ -21,6 +21,7 @@ jobs:
           package-name: ${{ inputs.package-name }}
           release-labels: 'type: release'
           include-v-in-tag: false
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN}}
           changelog-types: >
             [
               { "type": "build", "hidden": true },


### PR DESCRIPTION
<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- Adds a personal access token from the spacecadets-infra@truss.works Github Account so that Release Please can trigger status checks and deploy workflow. Ref: https://github.com/google-github-actions/release-please-action#github-credentials
## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
