### PR TITLE
ci: restore docker cache tags

### DIFF
--- a/.github/workflows/reusable-docker-cache-keystone-cms.yml
+++ b/.github/workflows/reusable-docker-cache-keystone-cms.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           context: ./ussf-portal-cms
           tags: keystone-cms:e2e
-          cache-to: type=local,mode=max,dest=/tmp/keystone-cms
+          cache-to: type=local,mode=max,dest=/tmp/keystone-cms,tag=e2e
           target: e2e
 
       - name: Get docker image digest from manifest

--- a/.github/workflows/reusable-docker-cache-personnel-api.yml
+++ b/.github/workflows/reusable-docker-cache-personnel-api.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           context: ./ussf-personnel-api 
           tags: personnel-api:builder
-          cache-to: type=local,mode=max,dest=/tmp/personnel-api
+          cache-to: type=local,mode=max,dest=/tmp/personnel-api,tag=builder
           target: builder
 
       - name: Get docker image digest from manifest

--- a/.github/workflows/reusable-docker-cache-portal-client.yml
+++ b/.github/workflows/reusable-docker-cache-portal-client.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           context: ./ussf-portal-client
           tags: portal-client:e2e
-          cache-to: type=local,mode=max,dest=/tmp/portal-client
+          cache-to: type=local,mode=max,dest=/tmp/portal-client,tag=e2e
           target: e2e
           
       - name: Get docker image digest from manifest

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile
       target: e2e
       cache_from:
-        - 'type=local,src=/tmp/portal-client'
+        - 'type=local,src=/tmp/portal-client,tag=e2e'
     restart: always
     ports:
       - '3000:3000'
@@ -43,7 +43,7 @@ services:
       dockerfile: Dockerfile
       target: 'e2e${LOCAL_BUILD}'
       cache_from:
-        - 'type=local,src=/tmp/keystone-cms'
+        - 'type=local,src=/tmp/keystone-cms,tag=e2e'
     ports:
       - '3001:3001'
     environment:
@@ -87,7 +87,7 @@ services:
       dockerfile: Dockerfile
       target: builder
       cache_from:
-        - 'type=local,src=/tmp/personnel-api'
+        - 'type=local,src=/tmp/personnel-api,tag=builder'
     restart: always
     ports:
       - '4000:4000'


### PR DESCRIPTION
<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- Restores `e2e` and `builder` tags to the Docker `cache-to` and `cache-from` commands. Some PRs are getting this error `"local cache importer requires either explicit digest, \"latest\" tag or custom tag on index.json"` which seems to imply that an explicit tag is needed even though the default `latest` should do. https://github.com/moby/buildkit/blob/1efcd30d9dd67fc20bd1ec641ea6659f6e74f0d8/client/solve.go#L499C28-L499C126
## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
