### PR TITLE
feat: Support published status for landing pages and preview of draft pages

### DIFF
--- a/e2e/playwright/feature/article-preview.spec.ts
+++ b/e2e/playwright/feature/article-preview.spec.ts
@@ -86,7 +86,7 @@ describe('orbit blog', () => {
 
     // Ensure preview banner is present
     await expect(
-      article.locator('article >> h2:has-text("Unpublished Article Preview")')
+      article.locator('article >> h2:has-text("Draft Article Preview")')
     ).toBeVisible()
 
     // Ensure article title is present
@@ -152,7 +152,7 @@ describe('orbit blog', () => {
 
     // Ensure preview banner is present
     await expect(
-      article.locator('article >> h2:has-text("Unpublished Article Preview")')
+      article.locator('article >> h2:has-text("Draft Article Preview")')
     ).toBeHidden()
 
     // Ensure article title is present
@@ -225,7 +225,7 @@ describe('internal news', () => {
 
     // Ensure preview banner is present
     await expect(
-      article.locator('article >> h2:has-text("Unpublished Article Preview")')
+      article.locator('article >> h2:has-text("Draft Article Preview")')
     ).toBeVisible()
 
     // Ensure article title is present
@@ -290,7 +290,7 @@ describe('internal news', () => {
 
     // Ensure preview banner is present
     await expect(
-      article.locator('article >> h2:has-text("Unpublished Article Preview")')
+      article.locator('article >> h2:has-text("Draft Article Preview")')
     ).toBeHidden()
 
     // Ensure article title is present

--- a/e2e/playwright/feature/landing-page.spec.ts
+++ b/e2e/playwright/feature/landing-page.spec.ts
@@ -5,7 +5,7 @@ import {
   fixtures,
   TestingLibraryFixtures,
 } from '@playwright-testing-library/test/fixture'
-import { adminUser } from '../cms/database/users'
+import { adminUser, portalUser1 } from '../cms/database/users'
 import { LoginPage } from '../models/Login'
 
 type CustomFixtures = {
@@ -125,6 +125,10 @@ test('can create a landing page in the CMS and view it in the portal', async ({
   // Save Landing Page
   await page.getByRole('button', { name: 'Create Landing Page' }).click()
 
+  // Publish Landing Page
+  await page.getByText('Published', { exact: true }).click()
+  await page.getByRole('button', { name: 'Save changes' }).click()
+
   // Navigate to the portal
   await page.goto('http://localhost:3000/')
   await page.getByRole('link', { name: 'Landing Pages' }).click()
@@ -152,5 +156,34 @@ test('can create a landing page in the CMS and view it in the portal', async ({
 
   expect(page1.url()).toBe(
     `http://localhost:3000/landing/${landingPageSlug}/${articleSlug}`
+  )
+})
+
+test('portal user can see published landing page', async ({
+  page,
+  loginPage,
+}) => {
+  // try to go to the landing page as default user
+  await loginPage.login(portalUser1.username, portalUser1.password)
+  await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
+
+  await page.getByRole('link', { name: 'Landing Pages' }).click()
+  await expect(
+    page.getByRole('heading', { name: 'Landing Pages' })
+  ).toBeVisible()
+
+  // Navigate to the landing page
+  await page.getByRole('link', { name: landingPageTitle }).click()
+
+  // These headings are only visible when there is content in the section, so
+  // if they are visible, we know the content is there
+  await expect(
+    page.getByRole('heading', { name: 'Documentation' })
+  ).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Collections' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Articles' })).toBeVisible()
+
+  expect(page.url()).toBe(
+    `http://localhost:3000/landing/${landingPageSlug}`
   )
 })

--- a/e2e/playwright/feature/landing-preview.spec.ts
+++ b/e2e/playwright/feature/landing-preview.spec.ts
@@ -1,0 +1,122 @@
+import { test as base } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  fixtures,
+  TestingLibraryFixtures,
+} from '@playwright-testing-library/test/fixture'
+import { adminUser, portalUser1 } from '../cms/database/users'
+import { LoginPage } from '../models/Login'
+
+type CustomFixtures = {
+  loginPage: LoginPage
+}
+
+const test = base.extend<TestingLibraryFixtures & CustomFixtures>({
+  ...fixtures,
+  loginPage: async ({ page, context }, use) => {
+    await use(new LoginPage(page, context))
+  },
+})
+
+const { expect } = test
+
+const tagTitle = faker.lorem.words()
+const landingPageTitle = faker.lorem.words()
+const landingPageSlug = faker.helpers.slugify(landingPageTitle)
+const landingPageDescription = faker.lorem.words()
+
+test('can create a draft landing page in the CMS and view it in the portal', async ({
+  page,
+  loginPage,
+}) => {
+  await loginPage.login(adminUser.username, adminUser.password)
+
+  await expect(page.locator('text=WELCOME, FLOYD KING')).toBeVisible()
+
+  await page.goto('http://localhost:3001/')
+
+  await expect(
+    page.locator('text=FLOYD.KING.376144527@testusers.cce.af.mil')
+  ).toBeVisible()
+
+  // Create Landing Page
+  await page.getByRole('link', { name: 'Landing Page', exact: true }).click()
+  await page.waitForSelector('text=Create Landing Page')
+  await page.getByRole('link', { name: 'Create Landing Page' }).click()
+  await page.getByLabel('Page Title').click()
+  await page.getByLabel('Page Title').fill(landingPageTitle)
+  await page.getByLabel('Slug').click()
+  await page.getByLabel('Slug').fill(landingPageSlug)
+  await page.getByLabel('Page Description').click()
+  await page.getByLabel('Page Description').fill(landingPageDescription)
+
+  // Add collections
+  await page.getByRole('group', { name: 'Collections' }).locator('svg').click()
+  await page.getByText('Career', { exact: true }).click()
+
+  // Add tag
+  await page.getByRole('button', { name: 'Create related Tag' }).click()
+  await page.getByLabel('Name').click()
+  await page.getByLabel('Name').fill(tagTitle)
+  await page.getByRole('button', { name: 'Create Tag' }).click()
+
+  // Save Landing Page
+  await page.getByRole('button', { name: 'Create Landing Page' }).click()
+
+  await expect(page.getByRole('radio', { name: 'Draft' })).toBeChecked()
+  await expect(page.getByRole('button', { name: 'Preview Landing Page' })).toBeVisible()
+
+  // Start waiting for new page before clicking
+  // and Click preview button
+  const [landing] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.locator('button:has-text("Preview Landing Page")').click(),
+  ])
+
+  // Ensure preview banner is present
+  await expect(
+    landing.getByRole('heading', { name: 'Draft Landing Page Preview' })
+  ).toBeVisible()
+
+  // Ensure title is present
+  await expect(
+    landing.getByRole('heading', { name: landingPageTitle })
+  ).toBeVisible()
+
+  // close the tab
+  await landing.close()
+
+  // ensure the landing page is on the index page and has it's tag
+  await page.goto('http://localhost:3000')
+  await page.getByRole('link', { name: 'Landing Pages' }).click()
+  await expect(page.getByRole('cell', { name: `${landingPageTitle} Draft`, exact: true })).toBeVisible()
+
+  // return to the CMS and log out
+  await page.goto('http://localhost:3001')
+  await loginPage.logout()
+})
+
+test('draft landing page cannot be seen by portal user', async ({
+  page,
+  loginPage,
+}) => {
+  // try to go to the landing page as default user
+  await loginPage.login(portalUser1.username, portalUser1.password)
+  await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
+
+  await page.getByRole('link', { name: 'Landing Pages' }).click()
+  await expect(
+    page.getByRole('heading', { name: 'Landing Pages' })
+  ).toBeVisible()
+
+  await expect(page.getByRole('cell', { name: `${landingPageTitle} Draft`, exact: true })).toBeHidden()
+  // Try to Navigate to the landing page
+  await expect(page.getByRole('link', { name: landingPageTitle })).toBeHidden()
+  const defaultResponse = await page.request.get(
+    `http://localhost:3000/landing/${landingPageSlug}`
+  )
+  expect(defaultResponse.status()).toBe(404)
+
+  // logout of portal user
+  await page.locator('[data-testid="header"] [data-testid="button"]').click()
+})


### PR DESCRIPTION
# SC-2577

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
Add tests for the new preview landing page feature. See https://github.com/USSF-ORBIT/ussf-portal-client/pull/1175 and https://github.com/USSF-ORBIT/ussf-portal-cms/pull/411. 

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
