### PR TITLE
Add label "no-merge" that can be used to stop automatic merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,17 +1,18 @@
 pull_request_rules:
   - name: Automatic queue on >=1 or >=2 approvals   # rule for Auto-Queueing PRs to Default Merge Queue
     conditions:
-      - "label!=no-merge"
       - and:
-        - author!=dependabot[bot] # if author is not dependabot
-        - author!=renovate[bot] # if author is not renovatebot
-      - or:
+        - "label!=no-merge"
         - and:
-          - "#approved-reviews-by>=2"
-          - "label=needs: 2 appeng approvals"
-        - and:
-          - "#approved-reviews-by>=1"
-          - "label!=needs: 2 appeng approvals"
+          - author!=dependabot[bot] # if author is not dependabot
+          - author!=renovate[bot] # if author is not renovatebot
+        - or:
+          - and:
+            - "#approved-reviews-by>=2"
+            - "label=needs: 2 appeng approvals"
+          - and:
+            - "#approved-reviews-by>=1"
+            - "label!=needs: 2 appeng approvals"
       - schedule=Mon-Fri 09:00-19:00[America/Los_Angeles] # schedule the PRs to be queued during PST work hours
     actions:
       queue:
@@ -19,11 +20,12 @@ pull_request_rules:
 
   - name: automatic merge from dependabot # rule for Auto-Queueing PRs to Dependabot Merge Queue
     conditions:
-      - "label!=no-merge"
-      - "#approved-reviews-by >= 1"
-      - or:
-        - author=dependabot[bot]
-        - author=renovate[bot]
+      - and:
+        - "label!=no-merge"
+        - "#approved-reviews-by >= 1"
+        - or:
+          - author=dependabot[bot]
+          - author=renovate[bot]
     actions:
       queue:
         name: dependabot-merge-queue

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,7 @@
 pull_request_rules:
   - name: Automatic queue on >=1 or >=2 approvals   # rule for Auto-Queueing PRs to Default Merge Queue
     conditions:
+      - "label!=no-merge"
       - and:
         - author!=dependabot[bot] # if author is not dependabot
         - author!=renovate[bot] # if author is not renovatebot
@@ -18,6 +19,7 @@ pull_request_rules:
 
   - name: automatic merge from dependabot # rule for Auto-Queueing PRs to Dependabot Merge Queue
     conditions:
+      - "label!=no-merge"
       - "#approved-reviews-by >= 1"
       - or:
         - author=dependabot[bot]


### PR DESCRIPTION
# SC-2934

## Proposed changes

Make Mergify recognize a new label "no-merge" which must not be present for it to merge. This allows devs to easily override/prevent Mergify from acting when needed.

## Setup

As far as I know, this has to be merged to be tested since it's mergify. The configuration has already been checked and is valid in Mergify.
