### PR TITLE
feat: add test for searching for landing pages

### DIFF
--- a/e2e/playwright/feature/landing-page.spec.ts
+++ b/e2e/playwright/feature/landing-page.spec.ts
@@ -195,3 +195,24 @@ test('portal user can see published landing page', async ({
 
   expect(page.url()).toBe(`http://localhost:3000/landing/${landingPageSlug}`)
 })
+
+test('landing page shows up in search', async ({
+  page,
+  loginPage,
+}) => {
+  // try to go to the landing page as default user
+  await loginPage.login(portalUser1.username, portalUser1.password)
+  await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
+
+  await page.goto('http://localhost:3000/search')
+  await page.getByTestId('search-input').fill(landingPageTitle)
+  await expect(page.getByTestId('search-input')).toHaveValue(
+    landingPageTitle
+  )
+  await page.getByRole('button', { name: 'Search' }).click()
+  const linkToLandingPage = page.getByRole('link', { name: `${landingPageTitle} (opens in a new window)` }) 
+  await expect(linkToLandingPage).toBeVisible()
+  const href = await linkToLandingPage.getAttribute('href')
+  expect(href).toEqual(`http://localhost:3000/landing/${landingPageSlug}`)
+  await expect(page.getByTestId('result-preview').getByText(landingPageDescription)).toBeVisible()
+})

--- a/e2e/playwright/feature/landing-page.spec.ts
+++ b/e2e/playwright/feature/landing-page.spec.ts
@@ -200,6 +200,7 @@ test('landing page shows up in search', async ({
   page,
   loginPage,
 }) => {
+  test.slow()
   // try to go to the landing page as default user
   await loginPage.login(portalUser1.username, portalUser1.password)
   await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()

--- a/e2e/playwright/feature/landing-page.spec.ts
+++ b/e2e/playwright/feature/landing-page.spec.ts
@@ -200,7 +200,6 @@ test('landing page shows up in search', async ({
   page,
   loginPage,
 }) => {
-  test.slow()
   // try to go to the landing page as default user
   await loginPage.login(portalUser1.username, portalUser1.password)
   await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()


### PR DESCRIPTION
# SC-2635

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
Add a test to ensure landing pages show up in search

Related PRs:
- https://github.com/USSF-ORBIT/ussf-portal-cms/pull/418
- https://github.com/USSF-ORBIT/ussf-portal-client/pull/1190

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
