### PR TITLE
feat: Show user their portal userId on the settings page

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -27,6 +27,7 @@ const config: PlaywrightTestConfig = {
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
     trace: 'retain-on-failure',
+    permissions: ["clipboard-read", "clipboard-write"],
   },
   workers: 1,
   retries: 3,

--- a/e2e/playwright/feature/settings.spec.ts
+++ b/e2e/playwright/feature/settings.spec.ts
@@ -29,7 +29,14 @@ describe('Settings page', () => {
     await expect(page.getByText('Your user id is: FLOYD.KING.376144527@testusers.cce.af.mil')).toBeVisible()
     await page.getByRole('button', { name: 'Copy To Clipboard' }).click()
     await expect(page.getByText('Copied!')).toBeVisible()
+
+    // Read the content of the clipboard
+    const clipboardContent = await page.evaluate('navigator.clipboard.readText()')
+    expect(clipboardContent).toEqual('FLOYD.KING.376144527@testusers.cce.af.mil')
+
+    // Button should revert to original text
     await expect(page.getByText('Copied!')).toBeHidden()
+    await expect(page.getByText('Copy To Clipboard')).toBeVisible()
  
     // logout of portal user
     await page.locator('[data-testid="header"] [data-testid="button"]').click()

--- a/e2e/playwright/feature/settings.spec.ts
+++ b/e2e/playwright/feature/settings.spec.ts
@@ -1,0 +1,37 @@
+import { test as base } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  fixtures,
+  TestingLibraryFixtures,
+} from '@playwright-testing-library/test/fixture'
+
+import { LoginPage } from '../models/Login'
+import { portalUser1, adminUser } from '../cms/database/users'
+
+type CustomFixtures = {
+  loginPage: LoginPage
+}
+
+const test = base.extend<TestingLibraryFixtures & CustomFixtures>({
+  ...fixtures,
+  loginPage: async ({ page, context }, use) => {
+    await use(new LoginPage(page, context))
+  },
+})
+
+const { describe, expect } = test
+
+describe('Settings page', () => {
+  test('can see userId and copy it to clipboard', async ({ page, loginPage }) => {
+    await loginPage.login(adminUser.username, adminUser.password)
+    await expect(page.locator('text=WELCOME, FLOYD')).toBeVisible()
+    await page.getByTestId('editName').click()
+    await expect(page.getByText('Your user id is: FLOYD.KING.376144527@testusers.cce.af.mil')).toBeVisible()
+    await page.getByRole('button', { name: 'Copy To Clipboard' }).click()
+    await expect(page.getByText('Copied!')).toBeVisible()
+    await expect(page.getByText('Copied!')).toBeHidden()
+ 
+    // logout of portal user
+    await page.locator('[data-testid="header"] [data-testid="button"]').click()
+  })
+})


### PR DESCRIPTION
# SC-3025

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
Add an e2e test for https://github.com/USSF-ORBIT/ussf-portal-client/pull/1196 to ensure that the new `userId` copy button works and the user id is displayed.

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
