### PR TITLE
fix: show no results if none found

### DIFF
--- a/e2e/playwright/feature/guardian-directory.spec.ts
+++ b/e2e/playwright/feature/guardian-directory.spec.ts
@@ -175,6 +175,50 @@ test('can search the guardian directory', async ({ page, loginPage }) => {
   await page.getByRole('button', { name: 'Reset search' }).click()
   // Inexplicably, counting the rows does not work here,
   // so let's check the first and last rows render
+  // This might be due to a bug see https://app.shortcut.com/orbit-truss/story/3126/guardian-directory-search-with-empty-string-returns-incomplete-list
+  await expect(page.getByTestId('0_FirstName')).toBeVisible()
+  await expect(page.getByTestId('7_FirstName')).toBeVisible()
+})
+
+test.only('shows no results if none are found', async ({ page, loginPage }) => {
+  // Log in as CMS admin
+  await loginPage.login(portalUser1.username, portalUser1.password)
+
+  await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
+  await page.locator('text=Guardian Directory').click()
+  await expect(
+    page.getByRole('heading', { name: 'Guardian Directory' })
+  ).toBeVisible()
+
+  // Wait for data to show
+  await page
+    .locator('[data-testid="guardian-directory-table"] tbody tr')
+    .first()
+    .waitFor()
+
+  // Check we have the full expected directory
+  expect(
+    await page
+      .locator('[data-testid="guardian-directory-table"] tbody tr')
+      .count()
+  ).toBe(9)
+
+  // Successfully search for a Guardian
+  await page.getByTestId('textInput').click()
+  await page.getByTestId('textInput').fill('noresults')
+  await page.getByTestId('form').getByTestId('button').click()
+
+  // We should NOT have any results
+  await expect(page.getByRole('heading', { name: 'There are no results that match that query.' })).toBeVisible()
+
+  // Reset search results returns full directory
+  await page.getByRole('button', { name: 'Reset search' }).click()
+
+  await expect(page.getByRole('heading', { name: 'There are no results that match that query.' })).toBeHidden()
+
+  // Inexplicably, counting the rows does not work here,
+  // so let's check the first and last rows render
+  // This might be due to a bug see https://app.shortcut.com/orbit-truss/story/3126/guardian-directory-search-with-empty-string-returns-incomplete-list
   await expect(page.getByTestId('0_FirstName')).toBeVisible()
   await expect(page.getByTestId('7_FirstName')).toBeVisible()
 })

--- a/e2e/playwright/feature/guardian-directory.spec.ts
+++ b/e2e/playwright/feature/guardian-directory.spec.ts
@@ -152,14 +152,17 @@ test('can search the guardian directory', async ({ page, loginPage }) => {
   await page.getByTestId('form').getByTestId('button').click()
   // Inexplicably, counting the rows does not work here,
   // so let's check the first and last rows render
+  // This might be due to a bug see https://app.shortcut.com/orbit-truss/story/3126/guardian-directory-search-with-empty-string-returns-incomplete-list
   await expect(page.getByTestId('0_FirstName')).toBeVisible()
   await expect(page.getByTestId('7_FirstName')).toBeVisible()
 
   // Searching for a non-matching input returns no results
   await page.getByTestId('textInput').click()
-  await page.getByTestId('textInput').fill('asdf')
+  await page.getByTestId('textInput').fill('noresults')
   await page.getByTestId('form').getByTestId('button').click()
-  await page.waitForSelector('[data-testid="guardian-directory-table"]')
+ 
+  // We should NOT have any results
+  await expect(page.getByRole('heading', { name: 'There are no results that match that query.' })).toBeVisible()
   // Same as above, counting the rows does not work here, so checking
   // that all rows are hidden manually
   await expect(page.getByTestId('0_FirstName')).toBeHidden()
@@ -173,48 +176,8 @@ test('can search the guardian directory', async ({ page, loginPage }) => {
 
   // Reset search results returns full directory
   await page.getByRole('button', { name: 'Reset search' }).click()
-  // Inexplicably, counting the rows does not work here,
-  // so let's check the first and last rows render
-  // This might be due to a bug see https://app.shortcut.com/orbit-truss/story/3126/guardian-directory-search-with-empty-string-returns-incomplete-list
-  await expect(page.getByTestId('0_FirstName')).toBeVisible()
-  await expect(page.getByTestId('7_FirstName')).toBeVisible()
-})
 
-test('shows no results if none are found', async ({ page, loginPage }) => {
-  // Log in as CMS admin
-  await loginPage.login(portalUser1.username, portalUser1.password)
-
-  await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
-  await page.locator('text=Guardian Directory').click()
-  await expect(
-    page.getByRole('heading', { name: 'Guardian Directory' })
-  ).toBeVisible()
-
-  // Wait for data to show
-  await page
-    .locator('[data-testid="guardian-directory-table"] tbody tr')
-    .first()
-    .waitFor()
-
-  // Check we have the full expected directory
-  expect(
-    await page
-      .locator('[data-testid="guardian-directory-table"] tbody tr')
-      .count()
-  ).toBe(9)
-
-  // Successfully search for a Guardian
-  await page.getByTestId('textInput').click()
-  await page.getByTestId('textInput').fill('noresults')
-  await page.getByTestId('form').getByTestId('button').click()
-
-  // We should NOT have any results
-  await expect(page.getByRole('heading', { name: 'There are no results that match that query.' })).toBeVisible()
-
-  // Reset search results returns full directory
-  await page.getByRole('button', { name: 'Reset search' }).click()
-
-  await expect(page.getByRole('heading', { name: 'There are no results that match that query.' })).toBeHidden()
+  await page.waitForSelector('[data-testid="guardian-directory-table"]')
 
   // Inexplicably, counting the rows does not work here,
   // so let's check the first and last rows render

--- a/e2e/playwright/feature/guardian-directory.spec.ts
+++ b/e2e/playwright/feature/guardian-directory.spec.ts
@@ -180,7 +180,7 @@ test('can search the guardian directory', async ({ page, loginPage }) => {
   await expect(page.getByTestId('7_FirstName')).toBeVisible()
 })
 
-test.only('shows no results if none are found', async ({ page, loginPage }) => {
+test('shows no results if none are found', async ({ page, loginPage }) => {
   // Log in as CMS admin
   await loginPage.login(portalUser1.username, portalUser1.password)
 


### PR DESCRIPTION
# SC-3125

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->

Adds a unit test for https://github.com/USSF-ORBIT/ussf-portal-client/pull/1199
I think I discovered a bug that I added to shortcut: https://app.shortcut.com/orbit-truss/story/3126/guardian-directory-search-with-empty-string-returns-incomplete-list

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
