### PR TITLE
test: Add LandingPage articles to search results

### DIFF
--- a/e2e/playwright/feature/landing-page.spec.ts
+++ b/e2e/playwright/feature/landing-page.spec.ts
@@ -196,23 +196,45 @@ test('portal user can see published landing page', async ({
   expect(page.url()).toBe(`http://localhost:3000/landing/${landingPageSlug}`)
 })
 
-test('landing page shows up in search', async ({
-  page,
-  loginPage,
-}) => {
-  // try to go to the landing page as default user
+test('landing page shows up in search', async ({ page, loginPage }) => {
   await loginPage.login(portalUser1.username, portalUser1.password)
   await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
 
   await page.goto('http://localhost:3000/search')
   await page.getByTestId('search-input').fill(landingPageTitle)
-  await expect(page.getByTestId('search-input')).toHaveValue(
-    landingPageTitle
-  )
+  await expect(page.getByTestId('search-input')).toHaveValue(landingPageTitle)
   await page.getByRole('button', { name: 'Search' }).click()
-  const linkToLandingPage = page.getByRole('link', { name: `${landingPageTitle} (opens in a new window)` }) 
+  const linkToLandingPage = page.getByRole('link', {
+    name: `${landingPageTitle} (opens in a new window)`,
+  })
   await expect(linkToLandingPage).toBeVisible()
   const href = await linkToLandingPage.getAttribute('href')
   expect(href).toEqual(`http://localhost:3000/landing/${landingPageSlug}`)
-  await expect(page.getByTestId('result-preview').getByText(landingPageDescription)).toBeVisible()
+  await expect(
+    page.getByTestId('result-preview').getByText(landingPageDescription)
+  ).toBeVisible()
+})
+
+test('article linked to a landing page shows up in search', async ({
+  page,
+  loginPage,
+}) => {
+  await loginPage.login(portalUser1.username, portalUser1.password)
+  await expect(page.locator('text=WELCOME, BERNIE')).toBeVisible()
+
+  await page.goto('http://localhost:3000/search')
+  await page.getByTestId('search-input').fill(articleTitle)
+  await expect(page.getByTestId('search-input')).toHaveValue(articleTitle)
+  await page.getByRole('button', { name: 'Search' }).click()
+  const linkToArticle = page.getByRole('link', {
+    name: `${articleTitle} (opens in a new window)`,
+  })
+  await expect(linkToArticle).toBeVisible()
+  const href = await linkToArticle.getAttribute('href')
+  expect(href).toEqual(
+    `http://localhost:3000/landing/${landingPageSlug}/${articleSlug}`
+  )
+  await expect(
+    page.getByTestId('result-preview').getByText(articlePreview)
+  ).toBeVisible()
 })


### PR DESCRIPTION
# SC-3010

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
- Add test to verify that an article with the `LandingPage` category appears in the search results with the proper permalink
<!-- description and/or list of proposed changes -->

## Reviewer notes
Related PR: https://github.com/USSF-ORBIT/ussf-portal-cms/pull/422
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
