### PR TITLE
build Use github dockerfile for client

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: client
     build:
       context: ../../ussf-portal-client/
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile-gh
       target: e2e
       cache_from:
         - 'type=local,src=/tmp/portal-client,tag=e2e'


### PR DESCRIPTION
# SC-###

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
For the Gravity work we created a `Dockerfile-gh` in the ussf-portal-client repo. E2E tests are not ready for gravity so this PR updates the build to use the github specific one.

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
