### PR TITLE
chore: add dod cert bundle to e2e tests workflow for gha

### DIFF
--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -43,6 +43,14 @@ jobs:
           # checkout the branch that started this pull request or stay on main if no such branch
           /usr/bin/git checkout --progress --force -B ${{github.head_ref}} origin/${{github.head_ref}} || echo "staying on main"
 
+      - name: Add DoD Certificate Bundle
+        env:
+          CERT_BUNDLE_SHA256: ${{ secrets.DOD_CA_CERT_BUNDLE_SHA256 }}
+        working-directory: ./ussf-portal-client
+        run: |
+          echo "$CERT_BUNDLE_SHA256" > scripts/dod_ca_cert_bundle.sha256
+          sudo bash scripts/add-dod-cas.sh
+          
       - name: Clone cms # defaults to checking out the reference or SHA for the event that triggered this workflow. Otherwise, uses the default branch.
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:


### PR DESCRIPTION
# SC-3045

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

This PR pulled out a change from PR #356 to update the gha workflow. We need to update the workflow separately so the corresponding branch on `ussf-portal-client` will be able to run e2e tests properly.

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
