### PR TITLE
chore: Un-skip e2e test now that code is merged in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ e2e/test-results
 # dotenv environment variables file
 .env
 .envrc.*
-e2e/.envrc
 
 tsconfig.tsbuildinfo
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [USSF Portal CMS](https://github.com/USSF-ORBIT/ussf-portal-cms)
 - [USSF Analytics](https://github.com/USSF-ORBIT/analytics)
 - [USSF Personnel API](https://github.com/USSF-ORBIT/ussf-personnel-api)
+- [USSF Third Party API](https://github.com/USSF-ORBIT/ussf-portal/tree/main/test-jwt-service)
 
 ## Development setup
 
@@ -28,7 +29,8 @@
 - [How to delete DocumentDB Snapshots](./how-to/how-to-del-docdb-snapshots.md)
 - [How to grant CMS access](./how-to/Grant-CMS-acess.md)
 - [How to use the SAML groups](./how-to/use-saml-groups.md)
-- [How to generate a JWT token](./how-to/generate-jwt-token.md)
+- [How to Test JWT Auth with MobileConnect](./how-to/generate-jwt-token.md)
+- [How to Test JWT Auth with Test JWT Service](./how-to/generate-jwt-test-service.md)
 
 ## Architectural Decision Records
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,6 +42,9 @@ Set these variables for Happo in a `.envrc.local` file (only needed for local de
 - `HAPPO_API_KEY` - specific happo account API key, stored in 1Password valut
 - `HAPPO_API_SECRET` - specific happo account API secret, stored in 1Password valut
 
+Set this variable when testing the third-party api to avoid local cert issues:
+- `NODE_TLS_REJECT_UNAUTHORIZED=0`
+
 These env variables are already set in `.envrc` and only need to be added to your local file if you want to override the defaults:
 
 - `SESSION_SECRET` - must be a string at least 32 chars, must be the same value set in the CMS application
@@ -191,12 +194,25 @@ Services include:
 - Persists volume `matomo_data`
 - Access at `http://localhost:8081`
 - Do not use `https` locally as the Matomo image is not setup for that locally
-- Credentials are in the 1Password Vault
+- Credentials are in the 1Password Vault 
 
 
 7. MariaDB
 - Stores Matomo Data
 - Persists volume `mariadb_data`
+
+8. Test JWT Issuer
+- Creates a valid JSON Web Token to use for auth-protected queries and mutations for the Third-Party API
+  - This API exposes Keystone and Portal data to other USSF apps such as Guardian One
+- Code for this service lives in the `ussf-portal` repo in the `test-jwt-service` directory.
+- Uses Dockerfile located in `ussf-portal/test-jwt-service/Dockerfile`
+- Requires environment variable named `JWT_DEV_CERT` located in `ussf-portal/e2e/.envrc.local` (You will need to create this file initially.) 
+  - The value for this variable can be found in the 1Password Vault under 'Test JWT Server Certs for Dev'
+- Requires DoD certs to run e2e tests locally
+  - In `ussf-portal-client`, create the file `scripts/dod_ca_cert_bundle.sha256`
+  - In 1Password vault, locate `DoD PKI CA Cert Bundle SHA256 Checksums` and copy the data for the latest version
+  - Paste the checksums in the `dod_ca_cert_bundle.sha256` file and save.
+
 
 To run the app in detached development mode (with hot reloading):
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,9 +42,6 @@ Set these variables for Happo in a `.envrc.local` file (only needed for local de
 - `HAPPO_API_KEY` - specific happo account API key, stored in 1Password valut
 - `HAPPO_API_SECRET` - specific happo account API secret, stored in 1Password valut
 
-Set this variable when testing the third-party api to avoid local cert issues:
-- `NODE_TLS_REJECT_UNAUTHORIZED=0`
-
 These env variables are already set in `.envrc` and only need to be added to your local file if you want to override the defaults:
 
 - `SESSION_SECRET` - must be a string at least 32 chars, must be the same value set in the CMS application

--- a/docs/how-to/generate-jwt-test-service.md
+++ b/docs/how-to/generate-jwt-test-service.md
@@ -13,7 +13,7 @@ Code for this service lives in the `ussf-portal` repo in the `test-jwt-service` 
 
 * In `ussf-portal-client/scripts`, create a file named `dod_ca_cert_bundle.sha256`. Look in the 1Password Vault under `DoD PKI CA Cert Bundle SHA256 Checksums`. Copy data for the latest version and paste into your new file.
 
-* Look in the 1Password Vault under 'Test JWT Server Certs for Dev'. Copy and paste the (very long) private key into `ussf-portal/e2e/.envrc.local` as the following: `JWT_DEV_CERT=<value>`
+* Look in the 1Password Vault under 'Test JWT Server Certs for Dev'. Copy and paste the (very long) private key into `ussf-portal/e2e/.envrc.local` as the following: `JWT_DEV_CERT="<value>"`
 
 ## Step 1: Set up Postman Collection 
 For easier testing, we have a Postman collections in the 1Password Vault named `USSF Third-Party API local`. This is slightly different than the [collection used for testing with MobileConnect](./generate-jwt-token.md), so make sure you have both.

--- a/docs/how-to/generate-jwt-test-service.md
+++ b/docs/how-to/generate-jwt-test-service.md
@@ -1,0 +1,44 @@
+# How to Test JWT Auth with Test JWT Service
+
+This guide is for using the Test JWT Service to generate a valid JWT for local testing of the Third-Party API. This service is also available to e2e tests.
+
+For testing with MobileConnect, [see this guide](./generate-jwt-token.md).
+
+Code for this service lives in the `ussf-portal` repo in the `test-jwt-service` directory.
+
+## Step 0: Check environment variables and service config
+
+* In `ussf-portal-client/.envrc.local`, set the following environment varible:
+`NODE_TLS_REJECT_UNAUTHORIZED=0`
+
+* In `ussf-portal-client/scripts`, create a file named `dod_ca_cert_bundle.sha256`. Look in the 1Password Vault under `DoD PKI CA Cert Bundle SHA256 Checksums`. Copy data for the latest version and paste into your new file.
+
+* Look in the 1Password Vault under 'Test JWT Server Certs for Dev'. Copy and paste the (very long) private key into `ussf-portal/e2e/.envrc.local` as the following: `JWT_DEV_CERT=<value>`
+
+## Step 1: Set up Postman Collection 
+For easier testing, we have a Postman collections in the 1Password Vault named `USSF Third-Party API local`. This is slightly different than the [collection used for testing with MobileConnect](./generate-jwt-token.md), so make sure you have both.
+
+Copy the file from 1P and import the collection into Postman.
+
+## Step 2: Run against local development
+
+### Start the services and app
+* In `ussf-portal-client`, run `yarn services:up`. Then run `yarn dev`.
+* In `ussf-portal-cms`, run `yarn dev`.
+
+### Get the userId
+* Log in to the portal using the test user of your choice. In this example, we'll use FLOYD KING (cmsadmin/cmsadminpass)
+* Go to `http://localhost:3000/settings` and copy the `userId`. For FLOYD, we've got `KING.FLOYD.376144527`.
+
+### Make the requests
+* In Postman, under `USSF Third-Party API local` collection in the sidebar, go to the request `Utility / Generate Token`. 
+* Under `Params`, enter the key `userId` and the value you copied from the portal. Send.
+* You should receive a response with a token, similar to:
+`{"token":"eyJhbGciOiJ...etcetcetc"}`. Postman automatically sets this token in the header for all future requests in the collection.
+* You can now send any of the requests under `Auth` and receive valid responses.
+
+## Step 2: Run local e2e tests
+* Stop the portal and cms applications. Go to `ussf-portal/e2e` and make sure you have no services up by running `yarn services:removeall`.
+* In `ussf-portal/e2e`, run `yarn services:up`. This will run all services, including the portal and cms, in Docker.
+* Once Docker is done building, you can now run `yarn e2e:test` and it can connect to the test service. This means you can write tests against the third-party API by generating a token first (see `e2e/playwright/feature/jwt-auth.spec` for example.)
+* You can also use the app and service in the same way as in Step 1, making requests using Postman.

--- a/docs/how-to/generate-jwt-token.md
+++ b/docs/how-to/generate-jwt-token.md
@@ -1,4 +1,5 @@
-# How to Test JWT Auth for Mobile Connect <-> USSF Portal
+# How to Test JWT Auth with MobileConnect
+This guide is for using your real credentials with a CAC and MobileConnect. For instructions on testing locally or in e2e tests with fake users, see [How to Test JWT Auth with Test JWT Service](./generate-jwt-test-service.md).
 
 ## Step 0: Grab user info from dev
 

--- a/e2e/.envrc
+++ b/e2e/.envrc
@@ -1,0 +1,4 @@
+
+# Load a local overrides file. Any changes you want to make for your local
+# environment should live in that file.
+[[ -f .envrc.local ]] && source_env .envrc.local

--- a/e2e/playwright/feature/jwt-auth.spec.ts
+++ b/e2e/playwright/feature/jwt-auth.spec.ts
@@ -22,7 +22,7 @@ test.beforeAll(async () => {
 })
 
 describe('JWT Authentication', () => {
-  test.skip('user can get valid token', async () => {
+  test('user can get valid token', async () => {
     // Make an API request
     const response = await axios.get(
       'http://localhost:5001/login?userId=KING.FLOYD.376144527'


### PR DESCRIPTION
# SC-3046

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

* Unskips e2e test for work on jwt test service.
* Allows .envrc to be checked in so we can have an .envrc.local that properly overrides and loads the dev cert
* Updates docs in `development.md`
* Adds new `How To` for using the service locally

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
