### PR TITLE
chore: add e2e test for jwt

### DIFF
--- a/e2e/playwright/feature/jwt-auth.spec.ts
+++ b/e2e/playwright/feature/jwt-auth.spec.ts
@@ -102,4 +102,27 @@ describe('JWT Authorization', () => {
       'User not authenticated'
     )
   })
+
+  test('request with bogus JWT will not work', async () => {
+    // John Doe token pulled from jwt.is
+    const fakeToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`
+    const headers = {
+      Authorization: `Bearer ${fakeToken}`,
+      'Content-Type': 'application/json',
+    }
+    const query = `
+      query getDisplayName {
+        displayName
+      }
+    `
+    const protectedResponse = await axios.post(
+      `http://localhost:3000/api/thirdparty/graphql`,
+      { query },
+      { headers }
+    )
+    expect(protectedResponse.status).toBe(200) // GraphQL always returns 200
+    expect(protectedResponse.data.errors[0].message).toBe(
+      'User not authenticated'
+    )
+  })
 })

--- a/e2e/playwright/feature/jwt-auth.spec.ts
+++ b/e2e/playwright/feature/jwt-auth.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@playwright-testing-library/test/fixture'
 import { LoginPage } from '../models/Login'
 import { seedDB } from '../portal-client/database/seedMongo'
+import { testUser1 } from '../portal-client/database/users'
 
 import axios from 'axios'
 type CustomFixtures = {
@@ -21,14 +22,84 @@ test.beforeAll(async () => {
   await seedDB()
 })
 
-describe('JWT Authentication', () => {
-  test.skip('user can get valid token', async () => {
-    // Make an API request
+describe('JWT Authorization', () => {
+  test('existing user can get valid token and make a request', async () => {
+    // Make an API request to get JWT
     const response = await axios.get(
-      'http://localhost:5001/login?userId=KING.FLOYD.376144527'
+      `http://localhost:5001/login?userId=${testUser1.userId}`
     )
-
     expect(response.status).toBe(200)
     expect(response.data).toHaveProperty('token')
+
+    // Make an API request to get a protected resource
+    const token = response.data.token
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+    const query = `
+      query getDisplayName {
+        displayName
+      }
+    `
+    const protectedResponse = await axios.post(
+      `http://localhost:3000/api/thirdparty/graphql`,
+      { query },
+      { headers }
+    )
+
+    expect(protectedResponse.status).toBe(200)
+    expect(protectedResponse.data.data.displayName).toBe(testUser1.displayName)
+  })
+
+  test('non-existing user can get a valid token and make a request', async () => {
+    // Make an API request to get JWT
+    const response = await axios.get(
+      `http://localhost:5001/login?userId=NEW.USER.0123456789`
+    )
+    expect(response.status).toBe(200)
+    expect(response.data).toHaveProperty('token')
+
+    // Make an API request to get a protected resource
+    const token = response.data.token
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+    const query = `
+      query getDisplayName {
+        displayName
+      }
+    `
+    const protectedResponse = await axios.post(
+      `http://localhost:3000/api/thirdparty/graphql`,
+      { query },
+      { headers }
+    )
+
+    expect(protectedResponse.status).toBe(200)
+    expect(protectedResponse.data.data.displayName).toBe('NEW.USER.0123456789')
+  })
+
+  test('unauth user cannot make a request to protected API calls', async () => {
+    // Make an API request to get a protected resource
+    const headers = {
+      'Content-Type': 'application/json',
+    }
+    const query = `
+      query getDisplayName {
+        displayName
+      }
+    `
+    const protectedResponse = await axios.post(
+      `http://localhost:3000/api/thirdparty/graphql`,
+      { query },
+      { headers }
+    )
+
+    expect(protectedResponse.status).toBe(200) // GraphQL always returns 200
+    expect(protectedResponse.data.errors[0].message).toBe(
+      'User not authenticated'
+    )
   })
 })


### PR DESCRIPTION
# SC-3202

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

* Adds e2e test coverage for different scenarios involving JWTs and the third-party API

## Reviewer notes

You'll need the companion branch from ussf-portal-client: https://github.com/USSF-ORBIT/ussf-portal-client/pull/1209

## Setup
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
