### PR TITLE
chore: update readme with relevant links, add placeholder for excalidraw links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # Table of Contents
 
-1. [About the Project](#about-the-project)
-    a. [Our Philosophy](#our-philosophy-and-process)
-    b. [Portal Links](#portal-links)
-    c. [Repository Directory](#repository-directory)
-2. [Developer Resources](#developer-resources)
-    a. [Documentation](#documentation)
-    b. [E2E Testing](#end-to-end-testing)
-3. [USSF Design](#ussf-design)
-4. [Infrastructure](#infrastructure)
+* [About the Project](#about-the-project)
+    * [Our Philosophy](#our-philosophy-and-process)
+    * [Portal Links](#portal-links)
+    * [Repository Directory](#repository-directory)
+* [Developer Resources](#developer-resources)
+    * [Documentation](#documentation)
+    * [E2E Testing](#end-to-end-testing)
+* [USSF Design](#ussf-design)
+* [Infrastructure](#infrastructure)
 
 ## About the Project
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
     * [Documentation](#documentation)
     * [E2E Testing](#end-to-end-testing)
 * [USSF Design](#ussf-design)
-* [Infrastructure](#infrastructure)
 
 ## About the Project
 
@@ -63,6 +62,3 @@ End to end (E2E) testing is an important part of our software engineering practi
 Read more about the design process behind the portal: [Design Elements](https://github.com/USSF-ORBIT/ussf-portal/blob/bddc7caa5f2d272d6ade5db9098705ba70a59a7e/design-elements.md).
 
 The USSF Design System can be viewed via Storybook at https://storybook.ussforbit.us/
-
-## Infrastructure
-TK

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USSF Portal
 
-# GitHub Table of Contents
+# Table of Contents
 
 1. [About the Project](#about-the-project)
     a. [Our Philosophy](#our-philosophy-and-process)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,68 @@
-| Home | [The Team](the-team) | [Design Elements](design-elements) | [Portal Updates](portal-updates) | [Acknowledgements](acknowledgements) |
+# USSF Portal
 
-# Welcome and overview
+# GitHub Table of Contents
 
-The USSF/CTIO team has been busy in 2021! This year, we’ve conducted more than 40 one-on-one interviews with Guardians (and have surveyed dozens more) in order to custom create a portal that best serves your needs.
+1. [About the Project](#about-the-project)
+    a. [Our Philosophy](#our-philosophy-and-process)
+    b. [Portal Links](#portal-links)
+    c. [Repository Directory](#repository-directory)
+2. [Developer Resources](#developer-resources)
+    a. [Documentation](#documentation)
+    b. [E2E Testing](#end-to-end-testing)
+3. [USSF Design](#ussf-design)
+4. [Infrastructure](#infrastructure)
 
-We’re excited for you to explore the portal’s new offerings, and encourage you to check out the beta, start to customize your experience, and share your feedback about what could be better. This is your SF service portal, by you and for you, and we’re looking forward to working hand in hand with you to keep improving it in the months to come. If you’re interested in seeing what work is planned for the coming months, check out our [portal roadmap](USSF-Portal-Product-Roadmap.md).
+## About the Project
 
-If you’re interested in adding content to the portal on behalf of your team, stay tuned; in late January, we’ll be releasing a formalized process for submitting information to be published on the portal. We’re currently working to develop the approval and publication processes, and we appreciate your patience as we set up a content management system that will support the long-term needs of Guardians.
+### Our philosophy and process
 
-#### Our philosophy and process
-
-The new Space Force service portal was created hand-in-hand with the people who will engage with the service portal itself: Space Force personnel. The TrussWorks contracting team that designed and engineered this platform conducted research with more than 100 Guardians, spending hundreds of hours learning about what Guardians need (and don’t need) in a portal. This early and continual focus on Guardians helped the team understand Space Force personnel’s preferences on topics such as connecting easily to frequently used websites or applications, news & events, frequently accessed forms, and staying up to date on military requirements, to name a few.
+The Space Force service portal was created hand-in-hand with the people who will engage with the service portal itself: Space Force personnel. The TrussWorks contracting team that designed and engineered this platform conducted research with more than 100 Guardians, spending hundreds of hours learning about what Guardians need (and don’t need) in a portal. This early and continual focus on Guardians helped the team understand Space Force personnel’s preferences on topics such as connecting easily to frequently used websites or applications, news & events, frequently accessed forms, and staying up to date on military requirements, to name a few.
 
 The team at TrussWorks strongly believes in building products based on feedback from the people who will actually be interacting with them, and using a process that allows the team to deliver a prototype and make improvements with small, frequent delivery cycles. Our agile delivery method helps the team effectively prioritize features and which problems to tackle (and in what order). If we find ourselves suddenly moving in an unhelpful direction, agile also allows us to make quick course corrections based on direct Guardian feedback. Our team has found that putting Space Force personnel at the center of our decision-making helps build not only a better product, but also helps build trust in government services.
 
-**As a team we have come to value…**
+**As a team we value…**
 
 - Individuals and interactions over processes and tools
 - Working software over comprehensive documentation
 - Customer collaboration over contract negotiation
 - Responding to change over following a plan
 
+### Portal Links
 
-# End to End Testing
+USSF Portal:
+* Dev: https://dev.ussforbit.us
+* Staging: https://staging.my.spaceforce.mil
+* Production: https://my.spaceforce.mil
+
+CMS for USSF Portal:
+* Dev: https://cms.ussforbit.us
+* Staging: https://staging.cms.spaceforce.mil
+* Production: https://cms.spaceforce.mil
+
+To run the portal on your local machine, please see the [Developer Documentation](https://github.com/USSF-ORBIT/ussf-portal/blob/bddc7caa5f2d272d6ade5db9098705ba70a59a7e/docs/development.md).
+
+### Repository Directory
+- [USSF Portal Client](https://github.com/USSF-ORBIT/ussf-portal-client)
+- [USSF Portal CMS](https://github.com/USSF-ORBIT/ussf-portal-cms)
+- [USSF Analytics](https://github.com/USSF-ORBIT/analytics)
+- [USSF Personnel API](https://github.com/USSF-ORBIT/ussf-personnel-api)
+- [USSF Third Party API](https://github.com/USSF-ORBIT/ussf-portal/tree/main/test-jwt-service)
+- [Spacecadets Dev (Infrastructure)](https://github.com/USSF-ORBIT/spacecadets-dev)
+
+## Developer Resources
+
+### Documentation
+Refer to the [`docs/README.md`](https://github.com/USSF-ORBIT/ussf-portal/blob/bddc7caa5f2d272d6ade5db9098705ba70a59a7e/docs/README.md) for important links to [developer documentation](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/development.md), how-tos, and architectural decision records. If you're a software engineer working on any part of the application, [this README](https://github.com/USSF-ORBIT/ussf-portal/blob/bddc7caa5f2d272d6ade5db9098705ba70a59a7e/docs/README.md) is the page to bookmark.
+
+### End to End Testing
 
 End to end (E2E) testing is an important part of our software engineering practice. It helps us ensure that all the various components of the system can interact together properly. It also helps raise our confidence in upgrades and improvements as they are built. Since our E2E testing spans more than one application (e.g. the portal-client and portal-cms repositories) and are dependant on all those applications the E2E tests live in this repository.
+
+## USSF Design
+
+Read more about the design process behind the portal: [Design Elements](https://github.com/USSF-ORBIT/ussf-portal/blob/bddc7caa5f2d272d6ade5db9098705ba70a59a7e/design-elements.md).
+
+The USSF Design System can be viewed via Storybook at https://storybook.ussforbit.us/
+
+## Infrastructure
+TK

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,12 @@
 
 ## Environment Setup
 
+For a high-level look of how the system is architected, review the following diagrams. Note: You will need to be a member of the GitHub organization to have access.
+
+<!-- TODO: Update links once diagram PR is merged in -->
+* SAML Auth Flow 🔒
+* App Architecture 🔒
+
 ### Pre-requisites
 
 1. **Set up [direnv](https://direnv.net/docs/hook.html)**

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,9 +15,8 @@
 
 For a high-level look of how the system is architected, review the following diagrams. Note: You will need to be a member of the GitHub organization to have access.
 
-<!-- TODO: Update links once diagram PR is merged in -->
-* SAML Auth Flow 🔒
-* App Architecture 🔒
+* [SAML Auth Flow](https://github.com/USSF-ORBIT/spacecadets-dev/blob/d728708977d694428ee0d25598efbba706caaf2d/docs/diagrams/app-engineering/auth_flow.png) 🔒
+* [App Architecture](https://github.com/USSF-ORBIT/spacecadets-dev/blob/d728708977d694428ee0d25598efbba706caaf2d/docs/diagrams/app-engineering/app_architecture.png) 🔒
 
 ### Pre-requisites
 


### PR DESCRIPTION
# SC-###

This is a wild attempt on my part to refresh the README with more relevant links to project documentation. Definitely a group effort, so please feel free to pull down the branch, make changes, add your relevant sections (cc design, infra), etc. Or let me know if it's terrible and you want me to put it back! TEAMWORK.

Also added a placeholder for links to excalidraw diagrams which are in a PR here: https://github.com/USSF-ORBIT/spacecadets-dev/pull/169
## Proposed changes

<!-- description and/or list of proposed changes -->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
